### PR TITLE
Closes #37 migrate some non-true "deps" of `Suggests` to `Config/needs/website` framework

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,17 +28,18 @@ Imports:
     purrr,
     rlang
 Suggests:
-    admiral,
-    arrow,
-    gt,
-    gtsummary,
     knitr,
-    quarto,
     rmarkdown,
-    sdtm.oak,
     shiny,
     testthat (>= 3.0.0),
     yaml
 Config/testthat/edition: 3
+Config/Needs/website:
+    admiral,
+    arrow,
+    cards,
+    gt,
+    gtsummary,
+    sdtm.oak
 VignetteBuilder:
     knitr


### PR DESCRIPTION
## Summary
- Moved vignette-only packages (`admiral`, `arrow`, `gt`, `gtsummary`, `sdtm.oak`) from `Suggests` to `Config/Needs/website` following tidyverse conventions
- Added `cards` to `Config/Needs/website` (used in `ARS_example.Rmd` but previously undeclared)
- Removed `quarto` from `Suggests` (unused as an R package; the Quarto CLI is installed separately in the GHA workflow)

## Details
Packages only needed to render pkgdown articles — not used in `R/`, `tests/`, or true vignettes — no longer inflate the `Suggests` footprint. The existing `setup-r-dependencies` step with `needs: website` already reads `Config/Needs/website`, so no workflow changes were needed. 
Per R packages textbook, use this framework for articles that demonstrate other package use cases but don't necessarily belong in Imports/Suggests

Closes #37