### PR TITLE
Fix 60/61: GitHub artifact hook providers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Suggests:
     knitr,
     rmarkdown,
     shiny,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 VignetteBuilder:
     knitr
 Config/Needs/website: admiral, arrow, cards, gt, gtsummary, sdtm.oak

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -392,6 +392,22 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
       next
     }
 
+    rel_path_parts <- strsplit(rel_path, "[\\/]+", perl = TRUE)[[1]]
+    if (
+      grepl("^([A-Za-z]:)?[\\/]", rel_path) ||
+        any(rel_path_parts == "..")
+    ) {
+      github_artifact_signal_missing(
+        reason = glue::glue(
+          "payload file `{rel_path}` for key `{key}` is outside the artifact bundle."
+        ),
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      next
+    }
+
     payload_path <- file.path(manifest_dir, rel_path)
     payload_path_norm <- normalizePath(
       payload_path,

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -1,0 +1,421 @@
+normalize_github_artifact_scalar <- function(x) {
+  if (is.null(x) || length(x) == 0) {
+    return(NULL)
+  }
+
+  if (!is.atomic(x) || length(x) != 1) {
+    return(NULL)
+  }
+
+  value <- as.character(x[[1]])
+  if (!nzchar(value)) {
+    return(NULL)
+  }
+
+  value
+}
+
+github_artifact_default_name <- function(lWorkflow) {
+  workflow_id <- lWorkflow$meta$ID %||% lWorkflow$uid %||% "workflow"
+  paste0("workr-", workflow_id)
+}
+
+github_artifact_config <- function(lConfig, lWorkflow = NULL) {
+  cfg <- lConfig$github_artifact %||% list()
+  stop_if(!is.list(cfg), "`lConfig$github_artifact` must be a list when provided.")
+
+  cfg$path <- normalize_github_artifact_scalar(cfg$path) %||% tempdir()
+  cfg$download_dir <- normalize_github_artifact_scalar(cfg$download_dir) %||% tempdir()
+  cfg$artifact_name <- normalize_github_artifact_scalar(cfg$artifact_name) %||%
+    if (!is.null(lWorkflow)) github_artifact_default_name(lWorkflow) else NULL
+  cfg$repo <- normalize_github_artifact_scalar(cfg$repo) %||%
+    normalize_github_artifact_scalar(Sys.getenv("GITHUB_REPOSITORY", unset = ""))
+  cfg$run_id <- normalize_github_artifact_scalar(cfg$run_id) %||%
+    normalize_github_artifact_scalar(Sys.getenv("GITHUB_RUN_ID", unset = ""))
+  cfg$policy <- normalize_github_artifact_scalar(cfg$policy)
+  cfg$on_missing <- normalize_github_artifact_scalar(cfg$on_missing) %||% "fatal"
+
+  cfg
+}
+
+github_artifact_match_rules <- function(keys, rules) {
+  if (is.null(rules)) {
+    return(rep(TRUE, length(keys)))
+  }
+
+  stop_if(!is.character(rules), "Artifact include/exclude rules must be character vectors.")
+
+  vapply(
+    keys,
+    function(key) {
+      any(vapply(
+        rules,
+        function(rule) {
+          identical(key, rule) || grepl(rule, key, perl = TRUE)
+        },
+        logical(1)
+      ))
+    },
+    logical(1)
+  )
+}
+
+github_artifact_select_keys <- function(keys, include = NULL, exclude = NULL) {
+  if (length(keys) == 0) {
+    return(character(0))
+  }
+
+  selected <- github_artifact_match_rules(keys, include)
+  if (!is.null(exclude)) {
+    selected <- selected & !github_artifact_match_rules(keys, exclude)
+  }
+
+  keys[selected]
+}
+
+github_artifact_bundle_dir <- function(base_path, artifact_name) {
+  file.path(base_path, artifact_name)
+}
+
+github_artifact_entry_file <- function(index, key) {
+  safe_key <- gsub("[^A-Za-z0-9._-]", "_", key)
+  sprintf("payload/%03d-%s.rds", index, safe_key)
+}
+
+github_artifact_repo_parts <- function(repo) {
+  repo <- normalize_github_artifact_scalar(repo)
+  stop_if(is.null(repo), "`lConfig$github_artifact$repo` must be set for GitHub artifact resolution.")
+
+  parts <- strsplit(repo, "/", fixed = TRUE)[[1]]
+  stop_if(length(parts) != 2 || !all(nzchar(parts)), "`lConfig$github_artifact$repo` must use the form `owner/repo`.")
+
+  list(owner = parts[[1]], repo = parts[[2]])
+}
+
+github_artifact_policy_label <- function(cfg) {
+  if (!is.null(cfg$run_id)) {
+    return("explicit")
+  }
+
+  cfg$policy %||% "latest_success"
+}
+
+github_artifact_signal_missing <- function(reason, on_missing, run_id, policy) {
+  msg <- glue::glue(
+    "Artifact restore failed for run-id {run_id %||% '<unresolved>'} (policy: {policy}): {reason}"
+  )
+
+  stop_if(!on_missing %in% c("fatal", "warn"), "`on_missing` must be either `fatal` or `warn`.")
+
+  if (identical(on_missing, "warn")) {
+    LogMessage(level = "warn", message = "{msg}")
+    return(invisible(FALSE))
+  }
+
+  stop(msg, call. = FALSE)
+}
+
+gh_actions_latest_success_run_id <- function(repo) {
+  parts <- github_artifact_repo_parts(repo)
+  response <- gh::gh(
+    "GET /repos/{owner}/{repo}/actions/runs",
+    owner = parts$owner,
+    repo = parts$repo,
+    status = "success",
+    per_page = 1
+  )
+
+  runs <- response$workflow_runs %||% list()
+  if (length(runs) == 0) {
+    stop("No successful workflow runs found.", call. = FALSE)
+  }
+
+  as.character(runs[[1]]$id)
+}
+
+gh_actions_find_artifact <- function(repo, run_id, artifact_name) {
+  parts <- github_artifact_repo_parts(repo)
+  response <- gh::gh(
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+    owner = parts$owner,
+    repo = parts$repo,
+    run_id = run_id,
+    per_page = 100
+  )
+
+  artifacts <- response$artifacts %||% list()
+  if (length(artifacts) == 0) {
+    return(NULL)
+  }
+
+  if (is.null(artifact_name)) {
+    return(artifacts[[1]])
+  }
+
+  for (artifact in artifacts) {
+    if (identical(artifact$name, artifact_name)) {
+      return(artifact)
+    }
+  }
+
+  NULL
+}
+
+gh_actions_download_artifact_bundle <- function(repo, run_id, artifact_name, download_dir) {
+  artifact <- gh_actions_find_artifact(repo, run_id, artifact_name)
+  if (is.null(artifact)) {
+    stop(
+      glue::glue("Artifact `{artifact_name %||% '<first>'}` not found for run-id {run_id}."),
+      call. = FALSE
+    )
+  }
+
+  bundle_dir <- github_artifact_bundle_dir(download_dir, artifact$name)
+  dir.create(bundle_dir, recursive = TRUE, showWarnings = FALSE)
+
+  zip_path <- file.path(bundle_dir, "artifact.zip")
+  parts <- github_artifact_repo_parts(repo)
+  gh::gh(
+    "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
+    owner = parts$owner,
+    repo = parts$repo,
+    artifact_id = artifact$id,
+    .destfile = zip_path
+  )
+
+  utils::unzip(zip_path, exdir = bundle_dir)
+  unlink(zip_path)
+
+  bundle_dir
+}
+
+github_artifact_resolve_run_id <- function(cfg, lWorkflow, lConfig) {
+  if (!is.null(cfg$run_id)) {
+    return(cfg$run_id)
+  }
+
+  policy <- cfg$policy %||% "latest_success"
+  if (is.function(cfg$run_resolver)) {
+    return(as.character(cfg$run_resolver(
+      repo = cfg$repo,
+      policy = policy,
+      lWorkflow = lWorkflow,
+      lConfig = lConfig
+    )))
+  }
+
+  if (!identical(policy, "latest_success")) {
+    stop(glue::glue("Unsupported GitHub artifact policy `{policy}`."), call. = FALSE)
+  }
+
+  gh_actions_latest_success_run_id(cfg$repo)
+}
+
+github_artifact_fetch_bundle <- function(cfg, run_id, lWorkflow, lConfig) {
+  if (is.function(cfg$artifact_fetcher)) {
+    return(cfg$artifact_fetcher(
+      repo = cfg$repo,
+      run_id = run_id,
+      artifact_name = cfg$artifact_name,
+      download_dir = cfg$download_dir,
+      lWorkflow = lWorkflow,
+      lConfig = lConfig
+    ))
+  }
+
+  gh_actions_download_artifact_bundle(
+    repo = cfg$repo,
+    run_id = run_id,
+    artifact_name = cfg$artifact_name,
+    download_dir = cfg$download_dir
+  )
+}
+
+github_artifact_find_manifest <- function(bundle_dir) {
+  manifest_paths <- list.files(
+    bundle_dir,
+    pattern = "^manifest\\.ya?ml$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
+
+  if (length(manifest_paths) == 0) {
+    return(NULL)
+  }
+
+  manifest_paths[[1]]
+}
+
+github_artifact_save_provider <- function(lWorkflow, lConfig) {
+  cfg <- github_artifact_config(lConfig = lConfig, lWorkflow = lWorkflow)
+  keys <- names(lWorkflow$lData %||% list())
+  selected_keys <- github_artifact_select_keys(
+    keys = keys,
+    include = cfg$include,
+    exclude = cfg$exclude
+  )
+
+  bundle_dir <- github_artifact_bundle_dir(cfg$path, cfg$artifact_name)
+  payload_dir <- file.path(bundle_dir, "payload")
+  dir.create(payload_dir, recursive = TRUE, showWarnings = FALSE)
+
+  entries <- lapply(seq_along(selected_keys), function(index) {
+    key <- selected_keys[[index]]
+    rel_path <- github_artifact_entry_file(index, key)
+    saveRDS(lWorkflow$lData[[key]], file.path(bundle_dir, rel_path))
+    list(key = key, file = rel_path)
+  })
+
+  manifest <- list(
+    provider = "github_artifact",
+    artifact_name = cfg$artifact_name,
+    run_id = cfg$run_id,
+    workflow_id = lWorkflow$meta$ID %||% NULL,
+    retention_days = cfg$retention_days %||% NULL,
+    entries = entries
+  )
+
+  manifest_path <- file.path(bundle_dir, "manifest.yaml")
+  yaml::write_yaml(manifest, manifest_path)
+
+  if (is.function(cfg$uploader)) {
+    cfg$uploader(
+      bundle_dir = bundle_dir,
+      artifact_name = cfg$artifact_name,
+      retention_days = cfg$retention_days %||% NULL,
+      manifest_path = manifest_path,
+      lWorkflow = lWorkflow,
+      lConfig = lConfig
+    )
+  }
+
+  invisible(list(
+    bundle_dir = bundle_dir,
+    manifest_path = manifest_path,
+    selected_keys = selected_keys
+  ))
+}
+
+github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
+  cfg <- github_artifact_config(lConfig = lConfig, lWorkflow = lWorkflow)
+  policy <- github_artifact_policy_label(cfg)
+
+  run_id <- tryCatch(
+    github_artifact_resolve_run_id(cfg, lWorkflow, lConfig),
+    error = function(e) {
+      github_artifact_signal_missing(
+        reason = conditionMessage(e),
+        on_missing = cfg$on_missing,
+        run_id = cfg$run_id,
+        policy = policy
+      )
+      NULL
+    }
+  )
+  if (is.null(run_id)) {
+    return(lData)
+  }
+
+  bundle_dir <- tryCatch(
+    github_artifact_fetch_bundle(cfg, run_id, lWorkflow, lConfig),
+    error = function(e) {
+      github_artifact_signal_missing(
+        reason = conditionMessage(e),
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      NULL
+    }
+  )
+  if (is.null(bundle_dir)) {
+    return(lData)
+  }
+
+  manifest_path <- github_artifact_find_manifest(bundle_dir)
+  if (is.null(manifest_path)) {
+    github_artifact_signal_missing(
+      reason = "manifest.yaml is missing from the downloaded artifact bundle.",
+      on_missing = cfg$on_missing,
+      run_id = run_id,
+      policy = policy
+    )
+    return(lData)
+  }
+
+  manifest <- tryCatch(
+    yaml::read_yaml(manifest_path),
+    error = function(e) {
+      github_artifact_signal_missing(
+        reason = paste0("manifest.yaml could not be parsed: ", conditionMessage(e)),
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      NULL
+    }
+  )
+  if (is.null(manifest)) {
+    return(lData)
+  }
+
+  entries <- manifest$entries %||% list()
+  manifest_dir <- dirname(manifest_path)
+  restored <- lData
+
+  for (entry in entries) {
+    key <- entry$key %||% NULL
+    rel_path <- entry$file %||% NULL
+
+    if (is.null(key) || is.null(rel_path)) {
+      github_artifact_signal_missing(
+        reason = "manifest entry is missing `key` or `file`.",
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      next
+    }
+
+    payload_path <- file.path(manifest_dir, rel_path)
+    if (!file.exists(payload_path)) {
+      github_artifact_signal_missing(
+        reason = glue::glue("payload file `{rel_path}` is missing for key `{key}`."),
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      next
+    }
+
+    value <- tryCatch(
+      readRDS(payload_path),
+      error = function(e) {
+        github_artifact_signal_missing(
+          reason = glue::glue("payload file `{rel_path}` is corrupt for key `{key}`: {conditionMessage(e)}"),
+          on_missing = cfg$on_missing,
+          run_id = run_id,
+          policy = policy
+        )
+        NULL
+      }
+    )
+
+    if (!is.null(value)) {
+      restored[[key]] <- value
+    }
+  }
+
+  restored
+}
+
+workr_register_builtin_providers <- function() {
+  register_load_provider("github_artifact", github_artifact_load_provider)
+  register_save_provider("github_artifact", github_artifact_save_provider)
+  invisible(TRUE)
+}
+
+.onLoad <- function(libname, pkgname) {
+  workr_register_builtin_providers()
+  invisible(NULL)
+}

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -17,10 +17,14 @@ normalize_github_artifact_scalar <- function(x) {
 
 github_artifact_config <- function(lConfig, lWorkflow = NULL) {
   cfg <- lConfig$github_artifact %||% list()
-  stop_if(!is.list(cfg), "`lConfig$github_artifact` must be a list when provided.")
+  stop_if(
+    !is.list(cfg),
+    "`lConfig$github_artifact` must be a list when provided."
+  )
 
   cfg$path <- normalize_github_artifact_scalar(cfg$path) %||% tempdir()
-  cfg$download_dir <- normalize_github_artifact_scalar(cfg$download_dir) %||% tempdir()
+  cfg$download_dir <- normalize_github_artifact_scalar(cfg$download_dir) %||%
+    tempdir()
   cfg$artifact_name <- normalize_github_artifact_scalar(cfg$artifact_name) %||%
     if (!is.null(lWorkflow)) {
       workflow_id <- lWorkflow$meta$ID %||% lWorkflow$uid %||% "workflow"
@@ -29,11 +33,15 @@ github_artifact_config <- function(lConfig, lWorkflow = NULL) {
       NULL
     }
   cfg$repo <- normalize_github_artifact_scalar(cfg$repo) %||%
-    normalize_github_artifact_scalar(Sys.getenv("GITHUB_REPOSITORY", unset = ""))
+    normalize_github_artifact_scalar(Sys.getenv(
+      "GITHUB_REPOSITORY",
+      unset = ""
+    ))
   cfg$run_id <- normalize_github_artifact_scalar(cfg$run_id) %||%
     normalize_github_artifact_scalar(Sys.getenv("GITHUB_RUN_ID", unset = ""))
   cfg$policy <- normalize_github_artifact_scalar(cfg$policy)
-  cfg$on_missing <- normalize_github_artifact_scalar(cfg$on_missing) %||% "fatal"
+  cfg$on_missing <- normalize_github_artifact_scalar(cfg$on_missing) %||%
+    "fatal"
 
   cfg
 }
@@ -43,7 +51,10 @@ github_artifact_match_rules <- function(keys, rules) {
     return(rep(TRUE, length(keys)))
   }
 
-  stop_if(!is.character(rules), "Artifact include/exclude rules must be character vectors.")
+  stop_if(
+    !is.character(rules),
+    "Artifact include/exclude rules must be character vectors."
+  )
 
   vapply(
     keys,
@@ -75,10 +86,16 @@ github_artifact_select_keys <- function(keys, include = NULL, exclude = NULL) {
 
 github_artifact_repo_parts <- function(repo) {
   repo <- normalize_github_artifact_scalar(repo)
-  stop_if(is.null(repo), "`lConfig$github_artifact$repo` must be set for GitHub artifact resolution.")
+  stop_if(
+    is.null(repo),
+    "`lConfig$github_artifact$repo` must be set for GitHub artifact resolution."
+  )
 
   parts <- strsplit(repo, "/", fixed = TRUE)[[1]]
-  stop_if(length(parts) != 2 || !all(nzchar(parts)), "`lConfig$github_artifact$repo` must use the form `owner/repo`.")
+  stop_if(
+    length(parts) != 2 || !all(nzchar(parts)),
+    "`lConfig$github_artifact$repo` must use the form `owner/repo`."
+  )
 
   list(owner = parts[[1]], repo = parts[[2]])
 }
@@ -88,7 +105,10 @@ github_artifact_signal_missing <- function(reason, on_missing, run_id, policy) {
     "Artifact restore failed for run-id {run_id %||% '<unresolved>'} (policy: {policy}): {reason}"
   )
 
-  stop_if(!on_missing %in% c("fatal", "warn"), "`on_missing` must be either `fatal` or `warn`.")
+  stop_if(
+    !on_missing %in% c("fatal", "warn"),
+    "`on_missing` must be either `fatal` or `warn`."
+  )
 
   if (identical(on_missing, "warn")) {
     LogMessage(level = "warn", message = "{msg}")
@@ -126,11 +146,18 @@ gh_actions_find_artifact <- function(repo, run_id, artifact_name) {
   NULL
 }
 
-gh_actions_download_artifact_bundle <- function(repo, run_id, artifact_name, download_dir) {
+gh_actions_download_artifact_bundle <- function(
+  repo,
+  run_id,
+  artifact_name,
+  download_dir
+) {
   artifact <- gh_actions_find_artifact(repo, run_id, artifact_name)
   if (is.null(artifact)) {
     stop(
-      glue::glue("Artifact `{artifact_name %||% '<first>'}` not found for run-id {run_id}."),
+      glue::glue(
+        "Artifact `{artifact_name %||% '<first>'}` not found for run-id {run_id}."
+      ),
       call. = FALSE
     )
   }
@@ -171,7 +198,10 @@ github_artifact_resolve_run_id <- function(cfg, lWorkflow, lConfig) {
   }
 
   if (!identical(policy, "latest_success")) {
-    stop(glue::glue("Unsupported GitHub artifact policy `{policy}`."), call. = FALSE)
+    stop(
+      glue::glue("Unsupported GitHub artifact policy `{policy}`."),
+      call. = FALSE
+    )
   }
 
   parts <- github_artifact_repo_parts(cfg$repo)
@@ -245,7 +275,11 @@ github_artifact_save_provider <- function(lWorkflow, lConfig) {
 
 github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
   cfg <- github_artifact_config(lConfig = lConfig, lWorkflow = lWorkflow)
-  policy <- if (!is.null(cfg$run_id)) "explicit" else cfg$policy %||% "latest_success"
+  policy <- if (!is.null(cfg$run_id)) {
+    "explicit"
+  } else {
+    cfg$policy %||% "latest_success"
+  }
 
   run_id <- tryCatch(
     github_artifact_resolve_run_id(cfg, lWorkflow, lConfig),
@@ -301,7 +335,11 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
     recursive = TRUE,
     full.names = TRUE
   )
-  manifest_path <- if (length(manifest_paths) == 0) NULL else manifest_paths[[1]]
+  manifest_path <- if (length(manifest_paths) == 0) {
+    NULL
+  } else {
+    manifest_paths[[1]]
+  }
   if (is.null(manifest_path)) {
     github_artifact_signal_missing(
       reason = "manifest.yaml is missing from the downloaded artifact bundle.",
@@ -316,7 +354,10 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
     yaml::read_yaml(manifest_path),
     error = function(e) {
       github_artifact_signal_missing(
-        reason = paste0("manifest.yaml could not be parsed: ", conditionMessage(e)),
+        reason = paste0(
+          "manifest.yaml could not be parsed: ",
+          conditionMessage(e)
+        ),
         on_missing = cfg$on_missing,
         run_id = run_id,
         policy = policy
@@ -330,6 +371,11 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
 
   entries <- manifest$entries %||% list()
   manifest_dir <- dirname(manifest_path)
+  manifest_dir_norm <- normalizePath(
+    manifest_dir,
+    winslash = "/",
+    mustWork = TRUE
+  )
   restored <- lData
 
   for (entry in entries) {
@@ -347,9 +393,16 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
     }
 
     payload_path <- file.path(manifest_dir, rel_path)
-    if (!file.exists(payload_path)) {
+    payload_path_norm <- normalizePath(
+      payload_path,
+      winslash = "/",
+      mustWork = FALSE
+    )
+    if (!startsWith(payload_path_norm, paste0(manifest_dir_norm, "/"))) {
       github_artifact_signal_missing(
-        reason = glue::glue("payload file `{rel_path}` is missing for key `{key}`."),
+        reason = glue::glue(
+          "payload file `{rel_path}` for key `{key}` is outside the artifact bundle."
+        ),
         on_missing = cfg$on_missing,
         run_id = run_id,
         policy = policy
@@ -357,11 +410,27 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
       next
     }
 
+    if (!file.exists(payload_path)) {
+      github_artifact_signal_missing(
+        reason = glue::glue(
+          "payload file `{rel_path}` is missing for key `{key}`."
+        ),
+        on_missing = cfg$on_missing,
+        run_id = run_id,
+        policy = policy
+      )
+      next
+    }
+
+    read_succeeded <- TRUE
     value <- tryCatch(
       readRDS(payload_path),
       error = function(e) {
+        read_succeeded <<- FALSE
         github_artifact_signal_missing(
-          reason = glue::glue("payload file `{rel_path}` is corrupt for key `{key}`: {conditionMessage(e)}"),
+          reason = glue::glue(
+            "payload file `{rel_path}` is corrupt for key `{key}`: {conditionMessage(e)}"
+          ),
           on_missing = cfg$on_missing,
           run_id = run_id,
           policy = policy
@@ -370,8 +439,8 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
       }
     )
 
-    if (!is.null(value)) {
-      restored[[key]] <- value
+    if (read_succeeded) {
+      restored[key] <- list(value)
     }
   }
 

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -136,6 +136,7 @@ gh_actions_download_artifact_bundle <- function(repo, run_id, artifact_name, dow
   }
 
   bundle_dir <- file.path(download_dir, artifact$name)
+  unlink(bundle_dir, recursive = TRUE, force = TRUE)
   dir.create(bundle_dir, recursive = TRUE, showWarnings = FALSE)
 
   zip_path <- file.path(bundle_dir, "artifact.zip")
@@ -200,6 +201,7 @@ github_artifact_save_provider <- function(lWorkflow, lConfig) {
   )
 
   bundle_dir <- file.path(cfg$path, cfg$artifact_name)
+  unlink(bundle_dir, recursive = TRUE, force = TRUE)
   payload_dir <- file.path(bundle_dir, "payload")
   dir.create(payload_dir, recursive = TRUE, showWarnings = FALSE)
 

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -15,11 +15,6 @@ normalize_github_artifact_scalar <- function(x) {
   value
 }
 
-github_artifact_default_name <- function(lWorkflow) {
-  workflow_id <- lWorkflow$meta$ID %||% lWorkflow$uid %||% "workflow"
-  paste0("workr-", workflow_id)
-}
-
 github_artifact_config <- function(lConfig, lWorkflow = NULL) {
   cfg <- lConfig$github_artifact %||% list()
   stop_if(!is.list(cfg), "`lConfig$github_artifact` must be a list when provided.")
@@ -27,7 +22,12 @@ github_artifact_config <- function(lConfig, lWorkflow = NULL) {
   cfg$path <- normalize_github_artifact_scalar(cfg$path) %||% tempdir()
   cfg$download_dir <- normalize_github_artifact_scalar(cfg$download_dir) %||% tempdir()
   cfg$artifact_name <- normalize_github_artifact_scalar(cfg$artifact_name) %||%
-    if (!is.null(lWorkflow)) github_artifact_default_name(lWorkflow) else NULL
+    if (!is.null(lWorkflow)) {
+      workflow_id <- lWorkflow$meta$ID %||% lWorkflow$uid %||% "workflow"
+      paste0("workr-", workflow_id)
+    } else {
+      NULL
+    }
   cfg$repo <- normalize_github_artifact_scalar(cfg$repo) %||%
     normalize_github_artifact_scalar(Sys.getenv("GITHUB_REPOSITORY", unset = ""))
   cfg$run_id <- normalize_github_artifact_scalar(cfg$run_id) %||%
@@ -73,15 +73,6 @@ github_artifact_select_keys <- function(keys, include = NULL, exclude = NULL) {
   keys[selected]
 }
 
-github_artifact_bundle_dir <- function(base_path, artifact_name) {
-  file.path(base_path, artifact_name)
-}
-
-github_artifact_entry_file <- function(index, key) {
-  safe_key <- gsub("[^A-Za-z0-9._-]", "_", key)
-  sprintf("payload/%03d-%s.rds", index, safe_key)
-}
-
 github_artifact_repo_parts <- function(repo) {
   repo <- normalize_github_artifact_scalar(repo)
   stop_if(is.null(repo), "`lConfig$github_artifact$repo` must be set for GitHub artifact resolution.")
@@ -90,14 +81,6 @@ github_artifact_repo_parts <- function(repo) {
   stop_if(length(parts) != 2 || !all(nzchar(parts)), "`lConfig$github_artifact$repo` must use the form `owner/repo`.")
 
   list(owner = parts[[1]], repo = parts[[2]])
-}
-
-github_artifact_policy_label <- function(cfg) {
-  if (!is.null(cfg$run_id)) {
-    return("explicit")
-  }
-
-  cfg$policy %||% "latest_success"
 }
 
 github_artifact_signal_missing <- function(reason, on_missing, run_id, policy) {
@@ -113,24 +96,6 @@ github_artifact_signal_missing <- function(reason, on_missing, run_id, policy) {
   }
 
   stop(msg, call. = FALSE)
-}
-
-gh_actions_latest_success_run_id <- function(repo) {
-  parts <- github_artifact_repo_parts(repo)
-  response <- gh::gh(
-    "GET /repos/{owner}/{repo}/actions/runs",
-    owner = parts$owner,
-    repo = parts$repo,
-    status = "success",
-    per_page = 1
-  )
-
-  runs <- response$workflow_runs %||% list()
-  if (length(runs) == 0) {
-    stop("No successful workflow runs found.", call. = FALSE)
-  }
-
-  as.character(runs[[1]]$id)
 }
 
 gh_actions_find_artifact <- function(repo, run_id, artifact_name) {
@@ -170,7 +135,7 @@ gh_actions_download_artifact_bundle <- function(repo, run_id, artifact_name, dow
     )
   }
 
-  bundle_dir <- github_artifact_bundle_dir(download_dir, artifact$name)
+  bundle_dir <- file.path(download_dir, artifact$name)
   dir.create(bundle_dir, recursive = TRUE, showWarnings = FALSE)
 
   zip_path <- file.path(bundle_dir, "artifact.zip")
@@ -208,42 +173,21 @@ github_artifact_resolve_run_id <- function(cfg, lWorkflow, lConfig) {
     stop(glue::glue("Unsupported GitHub artifact policy `{policy}`."), call. = FALSE)
   }
 
-  gh_actions_latest_success_run_id(cfg$repo)
-}
-
-github_artifact_fetch_bundle <- function(cfg, run_id, lWorkflow, lConfig) {
-  if (is.function(cfg$artifact_fetcher)) {
-    return(cfg$artifact_fetcher(
-      repo = cfg$repo,
-      run_id = run_id,
-      artifact_name = cfg$artifact_name,
-      download_dir = cfg$download_dir,
-      lWorkflow = lWorkflow,
-      lConfig = lConfig
-    ))
-  }
-
-  gh_actions_download_artifact_bundle(
-    repo = cfg$repo,
-    run_id = run_id,
-    artifact_name = cfg$artifact_name,
-    download_dir = cfg$download_dir
-  )
-}
-
-github_artifact_find_manifest <- function(bundle_dir) {
-  manifest_paths <- list.files(
-    bundle_dir,
-    pattern = "^manifest\\.ya?ml$",
-    recursive = TRUE,
-    full.names = TRUE
+  parts <- github_artifact_repo_parts(cfg$repo)
+  response <- gh::gh(
+    "GET /repos/{owner}/{repo}/actions/runs",
+    owner = parts$owner,
+    repo = parts$repo,
+    status = "success",
+    per_page = 1
   )
 
-  if (length(manifest_paths) == 0) {
-    return(NULL)
+  runs <- response$workflow_runs %||% list()
+  if (length(runs) == 0) {
+    stop("No successful workflow runs found.", call. = FALSE)
   }
 
-  manifest_paths[[1]]
+  as.character(runs[[1]]$id)
 }
 
 github_artifact_save_provider <- function(lWorkflow, lConfig) {
@@ -255,13 +199,14 @@ github_artifact_save_provider <- function(lWorkflow, lConfig) {
     exclude = cfg$exclude
   )
 
-  bundle_dir <- github_artifact_bundle_dir(cfg$path, cfg$artifact_name)
+  bundle_dir <- file.path(cfg$path, cfg$artifact_name)
   payload_dir <- file.path(bundle_dir, "payload")
   dir.create(payload_dir, recursive = TRUE, showWarnings = FALSE)
 
   entries <- lapply(seq_along(selected_keys), function(index) {
     key <- selected_keys[[index]]
-    rel_path <- github_artifact_entry_file(index, key)
+    safe_key <- gsub("[^A-Za-z0-9._-]", "_", key)
+    rel_path <- sprintf("payload/%03d-%s.rds", index, safe_key)
     saveRDS(lWorkflow$lData[[key]], file.path(bundle_dir, rel_path))
     list(key = key, file = rel_path)
   })
@@ -298,7 +243,7 @@ github_artifact_save_provider <- function(lWorkflow, lConfig) {
 
 github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
   cfg <- github_artifact_config(lConfig = lConfig, lWorkflow = lWorkflow)
-  policy <- github_artifact_policy_label(cfg)
+  policy <- if (!is.null(cfg$run_id)) "explicit" else cfg$policy %||% "latest_success"
 
   run_id <- tryCatch(
     github_artifact_resolve_run_id(cfg, lWorkflow, lConfig),
@@ -317,7 +262,23 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
   }
 
   bundle_dir <- tryCatch(
-    github_artifact_fetch_bundle(cfg, run_id, lWorkflow, lConfig),
+    if (is.function(cfg$artifact_fetcher)) {
+      cfg$artifact_fetcher(
+        repo = cfg$repo,
+        run_id = run_id,
+        artifact_name = cfg$artifact_name,
+        download_dir = cfg$download_dir,
+        lWorkflow = lWorkflow,
+        lConfig = lConfig
+      )
+    } else {
+      gh_actions_download_artifact_bundle(
+        repo = cfg$repo,
+        run_id = run_id,
+        artifact_name = cfg$artifact_name,
+        download_dir = cfg$download_dir
+      )
+    },
     error = function(e) {
       github_artifact_signal_missing(
         reason = conditionMessage(e),
@@ -332,7 +293,13 @@ github_artifact_load_provider <- function(lWorkflow, lConfig, lData) {
     return(lData)
   }
 
-  manifest_path <- github_artifact_find_manifest(bundle_dir)
+  manifest_paths <- list.files(
+    bundle_dir,
+    pattern = "^manifest\\.ya?ml$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
+  manifest_path <- if (length(manifest_paths) == 0) NULL else manifest_paths[[1]]
   if (is.null(manifest_path)) {
     github_artifact_signal_missing(
       reason = "manifest.yaml is missing from the downloaded artifact bundle.",

--- a/R/workr-package.R
+++ b/R/workr-package.R
@@ -12,4 +12,5 @@
 #' @importFrom purrr keep map map2 map_chr map_dbl imap
 #' @importFrom utils capture.output read.csv str write.csv
 ## usethis namespace: end
+
 NULL

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -24,6 +24,13 @@ write_test_artifact_bundle <- function(bundle_dir, entries) {
   )
 }
 
+clear_github_artifact_env <- function() {
+  withr::local_envvar(c(
+    GITHUB_RUN_ID = "",
+    GITHUB_REPOSITORY = ""
+  ), .local_envir = parent.frame())
+}
+
 test_that("github_artifact save provider writes manifest and payload pair (#60)", {
   assign("identity_step", function(x) x, envir = .GlobalEnv)
   on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
@@ -102,6 +109,8 @@ test_that("github_artifact load provider restores data for an explicit run-id (#
 })
 
 test_that("github_artifact load provider resolves latest_success policy (#61)", {
+  clear_github_artifact_env()
+
   assign("identity_step", function(x) x, envir = .GlobalEnv)
   on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
 
@@ -139,6 +148,8 @@ test_that("github_artifact load provider resolves latest_success policy (#61)", 
 })
 
 test_that("github_artifact load provider errors with run-id and policy on missing artifact (#61)", {
+  clear_github_artifact_env()
+
   lWorkflow <- list(
     meta = list(Type = "demo", ID = "artifact_load_missing"),
     steps = list()

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -78,6 +78,36 @@ test_that("github_artifact save provider writes manifest and payload pair (#60)"
   expect_equal(uploader_args$retention_days, 30)
 })
 
+test_that("github_artifact save provider clears stale bundle contents (#60)", {
+  assign("identity_step", function(x) x, envir = .GlobalEnv)
+  on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
+
+  output_dir <- make_test_dir("save-provider-stale")
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  bundle_dir <- file.path(output_dir, "workr-artifact_save_stale")
+  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  stale_path <- file.path(bundle_dir, "payload", "stale.rds")
+  saveRDS("stale", stale_path)
+
+  suppressMessages(RunWorkflow(
+    lWorkflow = list(
+      meta = list(Type = "demo", ID = "artifact_save_stale"),
+      steps = list(
+        list(name = "identity_step", output = "results", params = list(x = "val"))
+      )
+    ),
+    lData = list(val = 7),
+    lConfig = list(
+      SaveData = "github_artifact",
+      github_artifact = list(path = output_dir)
+    )
+  ))
+
+  expect_false(file.exists(stale_path))
+  expect_true(file.exists(file.path(bundle_dir, "manifest.yaml")))
+})
+
 test_that("github_artifact load provider restores data for an explicit run-id (#61)", {
   assign("identity_step", function(x) x, envir = .GlobalEnv)
   on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
@@ -209,4 +239,51 @@ test_that("github_artifact load provider warns and returns partial lData when pa
   expect_equal(restored$existing, 1)
   expect_equal(restored$loaded_val, 42)
   expect_false("missing_val" %in% names(restored))
+})
+
+test_that("gh_actions_download_artifact_bundle clears stale extracted contents (#61)", {
+  download_dir <- make_test_dir("download-stale")
+  on.exit(unlink(download_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  bundle_dir <- file.path(download_dir, "workr-artifact")
+  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  stale_path <- file.path(bundle_dir, "payload", "stale.rds")
+  saveRDS("stale", stale_path)
+
+  local_mocked_bindings(
+    gh = function(endpoint, ..., .destfile = NULL) {
+      if (grepl("/actions/runs/.*/artifacts", endpoint)) {
+        return(list(artifacts = list(list(name = "workr-artifact", id = 123))))
+      }
+
+      if (grepl("/actions/artifacts/.*/zip", endpoint)) {
+        writeBin(charToRaw("zip"), .destfile)
+        return(invisible(NULL))
+      }
+
+      stop("Unexpected endpoint: ", endpoint)
+    },
+    .package = "gh"
+  )
+  local_mocked_bindings(
+    unzip = function(zipfile, exdir, ...) {
+      yaml::write_yaml(
+        list(provider = "github_artifact", entries = list()),
+        file.path(exdir, "manifest.yaml")
+      )
+      invisible(character(0))
+    },
+    .package = "utils"
+  )
+
+  restored_dir <- workr:::gh_actions_download_artifact_bundle(
+    repo = "Gilead-BioStats/workr",
+    run_id = "24680",
+    artifact_name = "workr-artifact",
+    download_dir = download_dir
+  )
+
+  expect_equal(restored_dir, bundle_dir)
+  expect_false(file.exists(stale_path))
+  expect_true(file.exists(file.path(bundle_dir, "manifest.yaml")))
 })

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -1,0 +1,200 @@
+make_test_dir <- function(prefix) {
+  path <- file.path(
+    tempdir(),
+    paste0(prefix, "-", Sys.getpid(), "-", as.integer(stats::runif(1, 1, 1e9)))
+  )
+  dir.create(path, recursive = TRUE, showWarnings = FALSE)
+  path
+}
+
+write_test_artifact_bundle <- function(bundle_dir, entries) {
+  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+
+  manifest_entries <- lapply(seq_along(entries), function(index) {
+    key <- names(entries)[[index]]
+    rel_path <- workr:::github_artifact_entry_file(index, key)
+    saveRDS(entries[[index]], file.path(bundle_dir, rel_path))
+    list(key = key, file = rel_path)
+  })
+
+  yaml::write_yaml(
+    list(provider = "github_artifact", entries = manifest_entries),
+    file.path(bundle_dir, "manifest.yaml")
+  )
+}
+
+test_that("github_artifact save provider writes manifest and payload pair (#60)", {
+  assign("identity_step", function(x) x, envir = .GlobalEnv)
+  on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
+
+  output_dir <- make_test_dir("save-provider")
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  uploader_args <- NULL
+  lWorkflow <- list(
+    meta = list(Type = "demo", ID = "artifact_save"),
+    steps = list(
+      list(name = "identity_step", output = "results", params = list(x = "val"))
+    )
+  )
+
+  suppressMessages({
+    RunWorkflow(
+      lWorkflow = lWorkflow,
+      lData = list(val = 7, qc = 11, secret = 99),
+      lConfig = list(
+        SaveData = "github_artifact",
+        github_artifact = list(
+          path = output_dir,
+          include = c("results", "qc"),
+          exclude = "secret",
+          retention_days = 30,
+          run_id = "12345",
+          uploader = function(...) {
+            uploader_args <<- list(...)
+          }
+        )
+      )
+    )
+  })
+
+  bundle_dir <- file.path(output_dir, "workr-artifact_save")
+  manifest <- yaml::read_yaml(file.path(bundle_dir, "manifest.yaml"))
+
+  expect_equal(manifest$artifact_name, "workr-artifact_save")
+  expect_equal(manifest$run_id, "12345")
+  expect_equal(manifest$retention_days, 30)
+  expect_setequal(vapply(manifest$entries, `[[`, character(1), "key"), c("results", "qc"))
+  expect_false(any(vapply(manifest$entries, `[[`, character(1), "key") == "secret"))
+  expect_true(file.exists(file.path(bundle_dir, manifest$entries[[1]]$file)))
+  expect_equal(uploader_args$retention_days, 30)
+})
+
+test_that("github_artifact load provider restores data for an explicit run-id (#61)", {
+  assign("identity_step", function(x) x, envir = .GlobalEnv)
+  on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
+
+  bundle_dir <- make_test_dir("load-explicit")
+  on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  write_test_artifact_bundle(bundle_dir, list(loaded_val = 42))
+
+  lWorkflow <- list(
+    meta = list(Type = "demo", ID = "artifact_load_explicit"),
+    steps = list(
+      list(name = "identity_step", output = "res", params = list(x = "loaded_val"))
+    )
+  )
+
+  result <- suppressMessages(RunWorkflow(
+    lWorkflow = lWorkflow,
+    lData = list(),
+    lConfig = list(
+      LoadData = "github_artifact",
+      github_artifact = list(
+        run_id = "67890",
+        artifact_fetcher = function(...) bundle_dir
+      )
+    )
+  ))
+
+  expect_equal(result, 42)
+})
+
+test_that("github_artifact load provider resolves latest_success policy (#61)", {
+  assign("identity_step", function(x) x, envir = .GlobalEnv)
+  on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
+
+  bundle_dir <- make_test_dir("load-policy")
+  on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  write_test_artifact_bundle(bundle_dir, list(loaded_val = 84))
+
+  resolved_policy <- NULL
+  lWorkflow <- list(
+    meta = list(Type = "demo", ID = "artifact_load_policy"),
+    steps = list(
+      list(name = "identity_step", output = "res", params = list(x = "loaded_val"))
+    )
+  )
+
+  result <- suppressMessages(RunWorkflow(
+    lWorkflow = lWorkflow,
+    lData = list(),
+    lConfig = list(
+      LoadData = "github_artifact",
+      github_artifact = list(
+        repo = "Gilead-BioStats/workr",
+        policy = "latest_success",
+        run_resolver = function(...) {
+          resolved_policy <<- list(...)$policy
+          "24680"
+        },
+        artifact_fetcher = function(...) bundle_dir
+      )
+    )
+  ))
+
+  expect_equal(result, 84)
+  expect_equal(resolved_policy, "latest_success")
+})
+
+test_that("github_artifact load provider errors with run-id and policy on missing artifact (#61)", {
+  lWorkflow <- list(
+    meta = list(Type = "demo", ID = "artifact_load_missing"),
+    steps = list()
+  )
+
+  expect_error(
+    suppressMessages(workr:::github_artifact_load_provider(
+      lWorkflow = lWorkflow,
+      lConfig = list(
+        github_artifact = list(
+          repo = "Gilead-BioStats/workr",
+          policy = "latest_success",
+          run_resolver = function(...) "13579",
+          artifact_fetcher = function(...) stop("artifact not found", call. = FALSE)
+        )
+      ),
+      lData = list()
+    )),
+    regexp = "run-id 13579.*policy: latest_success"
+  )
+})
+
+test_that("github_artifact load provider warns and returns partial lData when payloads are missing (#61)", {
+  bundle_dir <- make_test_dir("load-warn")
+  on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+
+  present_path <- workr:::github_artifact_entry_file(1, "loaded_val")
+  saveRDS(42, file.path(bundle_dir, present_path))
+  yaml::write_yaml(
+    list(
+      provider = "github_artifact",
+      entries = list(
+        list(key = "loaded_val", file = present_path),
+        list(key = "missing_val", file = workr:::github_artifact_entry_file(2, "missing_val"))
+      )
+    ),
+    file.path(bundle_dir, "manifest.yaml")
+  )
+
+  restored <- NULL
+  expect_message(
+    restored <- workr:::github_artifact_load_provider(
+      lWorkflow = list(meta = list(ID = "artifact_warn")),
+      lConfig = list(
+        github_artifact = list(
+          run_id = "11223",
+          on_missing = "warn",
+          artifact_fetcher = function(...) bundle_dir
+        )
+      ),
+      lData = list(existing = 1)
+    ),
+    regexp = "run-id 11223.*policy: explicit"
+  )
+
+  expect_equal(restored$existing, 1)
+  expect_equal(restored$loaded_val, 42)
+  expect_false("missing_val" %in% names(restored))
+})

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -8,7 +8,11 @@ make_test_dir <- function(prefix) {
 }
 
 write_test_artifact_bundle <- function(bundle_dir, entries) {
-  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(
+    file.path(bundle_dir, "payload"),
+    recursive = TRUE,
+    showWarnings = FALSE
+  )
 
   manifest_entries <- lapply(seq_along(entries), function(index) {
     key <- names(entries)[[index]]
@@ -25,10 +29,13 @@ write_test_artifact_bundle <- function(bundle_dir, entries) {
 }
 
 clear_github_artifact_env <- function() {
-  withr::local_envvar(c(
-    GITHUB_RUN_ID = "",
-    GITHUB_REPOSITORY = ""
-  ), .local_envir = parent.frame())
+  withr::local_envvar(
+    c(
+      GITHUB_RUN_ID = "",
+      GITHUB_REPOSITORY = ""
+    ),
+    .local_envir = parent.frame()
+  )
 }
 
 test_that("github_artifact save provider writes manifest and payload pair (#60)", {
@@ -72,8 +79,13 @@ test_that("github_artifact save provider writes manifest and payload pair (#60)"
   expect_equal(manifest$artifact_name, "workr-artifact_save")
   expect_equal(manifest$run_id, "12345")
   expect_equal(manifest$retention_days, 30)
-  expect_setequal(vapply(manifest$entries, `[[`, character(1), "key"), c("results", "qc"))
-  expect_false(any(vapply(manifest$entries, `[[`, character(1), "key") == "secret"))
+  expect_setequal(
+    vapply(manifest$entries, `[[`, character(1), "key"),
+    c("results", "qc")
+  )
+  expect_false(any(
+    vapply(manifest$entries, `[[`, character(1), "key") == "secret"
+  ))
   expect_true(file.exists(file.path(bundle_dir, manifest$entries[[1]]$file)))
   expect_equal(uploader_args$retention_days, 30)
 })
@@ -86,7 +98,11 @@ test_that("github_artifact save provider clears stale bundle contents (#60)", {
   on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
 
   bundle_dir <- file.path(output_dir, "workr-artifact_save_stale")
-  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(
+    file.path(bundle_dir, "payload"),
+    recursive = TRUE,
+    showWarnings = FALSE
+  )
   stale_path <- file.path(bundle_dir, "payload", "stale.rds")
   saveRDS("stale", stale_path)
 
@@ -94,7 +110,11 @@ test_that("github_artifact save provider clears stale bundle contents (#60)", {
     lWorkflow = list(
       meta = list(Type = "demo", ID = "artifact_save_stale"),
       steps = list(
-        list(name = "identity_step", output = "results", params = list(x = "val"))
+        list(
+          name = "identity_step",
+          output = "results",
+          params = list(x = "val")
+        )
       )
     ),
     lData = list(val = 7),
@@ -119,7 +139,11 @@ test_that("github_artifact load provider restores data for an explicit run-id (#
   lWorkflow <- list(
     meta = list(Type = "demo", ID = "artifact_load_explicit"),
     steps = list(
-      list(name = "identity_step", output = "res", params = list(x = "loaded_val"))
+      list(
+        name = "identity_step",
+        output = "res",
+        params = list(x = "loaded_val")
+      )
     )
   )
 
@@ -152,7 +176,11 @@ test_that("github_artifact load provider resolves latest_success policy (#61)", 
   lWorkflow <- list(
     meta = list(Type = "demo", ID = "artifact_load_policy"),
     steps = list(
-      list(name = "identity_step", output = "res", params = list(x = "loaded_val"))
+      list(
+        name = "identity_step",
+        output = "res",
+        params = list(x = "loaded_val")
+      )
     )
   )
 
@@ -193,7 +221,9 @@ test_that("github_artifact load provider errors with run-id and policy on missin
           repo = "Gilead-BioStats/workr",
           policy = "latest_success",
           run_resolver = function(...) "13579",
-          artifact_fetcher = function(...) stop("artifact not found", call. = FALSE)
+          artifact_fetcher = function(...) {
+            stop("artifact not found", call. = FALSE)
+          }
         )
       ),
       lData = list()
@@ -205,7 +235,11 @@ test_that("github_artifact load provider errors with run-id and policy on missin
 test_that("github_artifact load provider warns and returns partial lData when payloads are missing (#61)", {
   bundle_dir <- make_test_dir("load-warn")
   on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
-  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(
+    file.path(bundle_dir, "payload"),
+    recursive = TRUE,
+    showWarnings = FALSE
+  )
 
   present_path <- sprintf("payload/%03d-%s.rds", 1, "loaded_val")
   saveRDS(42, file.path(bundle_dir, present_path))
@@ -214,7 +248,10 @@ test_that("github_artifact load provider warns and returns partial lData when pa
       provider = "github_artifact",
       entries = list(
         list(key = "loaded_val", file = present_path),
-        list(key = "missing_val", file = sprintf("payload/%03d-%s.rds", 2, "missing_val"))
+        list(
+          key = "missing_val",
+          file = sprintf("payload/%03d-%s.rds", 2, "missing_val")
+        )
       )
     ),
     file.path(bundle_dir, "manifest.yaml")
@@ -241,12 +278,66 @@ test_that("github_artifact load provider warns and returns partial lData when pa
   expect_false("missing_val" %in% names(restored))
 })
 
+test_that("github_artifact load provider rejects payload paths outside bundle (#61)", {
+  bundle_dir <- make_test_dir("load-path-traversal")
+  on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  yaml::write_yaml(
+    list(
+      provider = "github_artifact",
+      entries = list(
+        list(key = "escaped", file = "../escaped.rds")
+      )
+    ),
+    file.path(bundle_dir, "manifest.yaml")
+  )
+
+  expect_error(
+    suppressMessages(workr:::github_artifact_load_provider(
+      lWorkflow = list(meta = list(ID = "artifact_path_traversal")),
+      lConfig = list(
+        github_artifact = list(
+          run_id = "33445",
+          artifact_fetcher = function(...) bundle_dir
+        )
+      ),
+      lData = list()
+    )),
+    regexp = "outside the artifact bundle"
+  )
+})
+
+test_that("github_artifact load provider restores NULL payload values (#61)", {
+  bundle_dir <- make_test_dir("load-null")
+  on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
+  write_test_artifact_bundle(bundle_dir, list(null_val = NULL))
+
+  restored <- suppressMessages(workr:::github_artifact_load_provider(
+    lWorkflow = list(meta = list(ID = "artifact_null")),
+    lConfig = list(
+      github_artifact = list(
+        run_id = "44556",
+        artifact_fetcher = function(...) bundle_dir
+      )
+    ),
+    lData = list(existing = 1)
+  ))
+
+  expect_equal(restored$existing, 1)
+  expect_true("null_val" %in% names(restored))
+  expect_null(restored$null_val)
+})
+
 test_that("gh_actions_download_artifact_bundle clears stale extracted contents (#61)", {
   download_dir <- make_test_dir("download-stale")
   on.exit(unlink(download_dir, recursive = TRUE, force = TRUE), add = TRUE)
 
   bundle_dir <- file.path(download_dir, "workr-artifact")
-  dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(
+    file.path(bundle_dir, "payload"),
+    recursive = TRUE,
+    showWarnings = FALSE
+  )
   stale_path <- file.path(bundle_dir, "payload", "stale.rds")
   saveRDS("stale", stale_path)
 

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -12,7 +12,8 @@ write_test_artifact_bundle <- function(bundle_dir, entries) {
 
   manifest_entries <- lapply(seq_along(entries), function(index) {
     key <- names(entries)[[index]]
-    rel_path <- workr:::github_artifact_entry_file(index, key)
+    safe_key <- gsub("[^A-Za-z0-9._-]", "_", key)
+    rel_path <- sprintf("payload/%03d-%s.rds", index, safe_key)
     saveRDS(entries[[index]], file.path(bundle_dir, rel_path))
     list(key = key, file = rel_path)
   })
@@ -165,14 +166,14 @@ test_that("github_artifact load provider warns and returns partial lData when pa
   on.exit(unlink(bundle_dir, recursive = TRUE, force = TRUE), add = TRUE)
   dir.create(file.path(bundle_dir, "payload"), recursive = TRUE, showWarnings = FALSE)
 
-  present_path <- workr:::github_artifact_entry_file(1, "loaded_val")
+  present_path <- sprintf("payload/%03d-%s.rds", 1, "loaded_val")
   saveRDS(42, file.path(bundle_dir, present_path))
   yaml::write_yaml(
     list(
       provider = "github_artifact",
       entries = list(
         list(key = "loaded_val", file = present_path),
-        list(key = "missing_val", file = workr:::github_artifact_entry_file(2, "missing_val"))
+        list(key = "missing_val", file = sprintf("payload/%03d-%s.rds", 2, "missing_val"))
       )
     ),
     file.path(bundle_dir, "manifest.yaml")


### PR DESCRIPTION
## Overview
Implemented built-in `github_artifact` save/load hook providers for the `fix-58` hook contract.

- Writes a manifest plus payload bundle for selected workflow outputs.
- Restores bundle contents by explicit `run_id` or `latest_success` policy.
- Supports `fatal` and `warn` behavior for missing or corrupt artifact contents.
- Registers the providers on package load and adds focused unit coverage for save/load behavior.

## Test Notes/Sample Code
`& 'C:\Program Files\R\R-4.4.1\bin\Rscript.exe' -e "pkgload::load_all('.'); testthat::test_file('tests/testthat/test-github-artifact-providers.R')"`

## Connected Issues
- Closes #60
- Closes #61
