### PR TITLE
Closes #62: Harden hook roundtrip coverage

### DIFF
--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -118,14 +118,58 @@ github_artifact_signal_missing <- function(reason, on_missing, run_id, policy) {
   stop(msg, call. = FALSE)
 }
 
+github_artifact_auth_hint <- function() {
+  paste(
+    "GitHub artifact restore requires a GitHub token with actions: read permission.",
+    "In GitHub Actions, expose the token as `GH_TOKEN` or `GITHUB_PAT`",
+    "and grant `permissions: actions: read`.",
+    "For fine-grained PATs, enable repository Actions access."
+  )
+}
+
+github_artifact_raise_api_error <- function(error, operation) {
+  msg <- conditionMessage(error)
+  is_auth_error <- grepl(
+    "401|403|bad credentials|requires authentication|resource not accessible by integration|forbidden|unauthorized",
+    msg,
+    ignore.case = TRUE
+  )
+
+  if (!is_auth_error) {
+    stop(msg, call. = FALSE)
+  }
+
+  stop(
+    paste(
+      "GitHub artifact",
+      operation,
+      "failed.",
+      github_artifact_auth_hint(),
+      "Original error:",
+      msg
+    ),
+    call. = FALSE
+  )
+}
+
+gh_actions_api <- function(endpoint, ..., operation) {
+  tryCatch(
+    gh::gh(endpoint, ...),
+    error = function(e) {
+      github_artifact_raise_api_error(error = e, operation = operation)
+    }
+  )
+}
+
 gh_actions_find_artifact <- function(repo, run_id, artifact_name) {
   parts <- github_artifact_repo_parts(repo)
-  response <- gh::gh(
+  response <- gh_actions_api(
     "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
     owner = parts$owner,
     repo = parts$repo,
     run_id = run_id,
-    per_page = 100
+    per_page = 100,
+    operation = "listing workflow artifacts"
   )
 
   artifacts <- response$artifacts %||% list()
@@ -168,12 +212,13 @@ gh_actions_download_artifact_bundle <- function(
 
   zip_path <- file.path(bundle_dir, "artifact.zip")
   parts <- github_artifact_repo_parts(repo)
-  gh::gh(
+  gh_actions_api(
     "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
     owner = parts$owner,
     repo = parts$repo,
     artifact_id = artifact$id,
-    .destfile = zip_path
+    .destfile = zip_path,
+    operation = "downloading workflow artifact bundles"
   )
 
   utils::unzip(zip_path, exdir = bundle_dir)
@@ -205,12 +250,13 @@ github_artifact_resolve_run_id <- function(cfg, lWorkflow, lConfig) {
   }
 
   parts <- github_artifact_repo_parts(cfg$repo)
-  response <- gh::gh(
+  response <- gh_actions_api(
     "GET /repos/{owner}/{repo}/actions/runs",
     owner = parts$owner,
     repo = parts$repo,
     status = "success",
-    per_page = 1
+    per_page = 1,
+    operation = "listing successful workflow runs"
   )
 
   runs <- response$workflow_runs %||% list()

--- a/R/utils-github-artifacts.R
+++ b/R/utils-github-artifacts.R
@@ -218,7 +218,7 @@ gh_actions_download_artifact_bundle <- function(
     repo = parts$repo,
     artifact_id = artifact$id,
     .destfile = zip_path,
-    operation = "downloading workflow artifact bundles"
+    operation = "downloading the workflow artifact bundle"
   )
 
   utils::unzip(zip_path, exdir = bundle_dir)

--- a/tests/testthat/test-github-artifact-providers.R
+++ b/tests/testthat/test-github-artifact-providers.R
@@ -205,6 +205,29 @@ test_that("github_artifact load provider resolves latest_success policy (#61)", 
   expect_equal(resolved_policy, "latest_success")
 })
 
+test_that("github_artifact load provider reports required Actions scope on auth failures (#62)", {
+  local_mocked_bindings(
+    gh = function(...) {
+      stop("HTTP 403 Forbidden: Resource not accessible by integration", call. = FALSE)
+    },
+    .package = "gh"
+  )
+
+  expect_error(
+    suppressMessages(workr:::github_artifact_load_provider(
+      lWorkflow = list(meta = list(Type = "demo", ID = "artifact_auth"), steps = list()),
+      lConfig = list(
+        github_artifact = list(
+          repo = "Gilead-BioStats/workr",
+          policy = "latest_success"
+        )
+      ),
+      lData = list()
+    )),
+    regexp = "actions: read"
+  )
+})
+
 test_that("github_artifact load provider errors with run-id and policy on missing artifact (#61)", {
   clear_github_artifact_env()
 

--- a/tests/testthat/test-hook-roundtrip.R
+++ b/tests/testthat/test-hook-roundtrip.R
@@ -1,0 +1,113 @@
+make_hook_roundtrip_workflow <- function(id = "hook_roundtrip") {
+  list(
+    meta = list(Type = "demo", ID = id),
+    steps = list(
+      list(
+        name = "identity_step",
+        output = "result",
+        params = list(x = "loaded_val")
+      )
+    )
+  )
+}
+
+make_hook_roundtrip_dir <- function(prefix) {
+  path <- file.path(
+    tempdir(),
+    paste0(prefix, "-", Sys.getpid(), "-", as.integer(stats::runif(1, 1, 1e9)))
+  )
+  dir.create(path, recursive = TRUE, showWarnings = FALSE)
+  path
+}
+
+test_that("hook providers round-trip data across runs (#62)", {
+  assign("identity_step", function(x) x, envir = .GlobalEnv)
+  on.exit(rm("identity_step", envir = .GlobalEnv), add = TRUE)
+
+  bundle_dir <- NULL
+  saved_state <- NULL
+  output_dir <- make_hook_roundtrip_dir("hook-roundtrip")
+  on.exit(unlink(output_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
+  local_mocked_bindings(
+    gsm_datasim_api = function() {
+      list(
+        create_standard_study_config = function(...) list(...),
+        generate_study_data = function(...) {
+          list(
+            "2024-01-31" = list(
+              Raw_SUBJ = data.frame(subjid = "S001", stringsAsFactors = FALSE),
+              loaded_val = 7
+            )
+          )
+        },
+        quick_longitudinal_study = function(...) {
+          stop("unexpected longitudinal call")
+        },
+        set_temporal_config = function(config, ...) config,
+        create_study_config = NULL,
+        add_dataset_config = NULL
+      )
+    },
+    .package = "workr"
+  )
+
+  workflow <- make_hook_roundtrip_workflow()
+
+  suppressMessages({
+    first_result <- RunWorkflow(
+      lWorkflow = workflow,
+      lData = list(),
+      lConfig = list(
+        LoadData = "gsm.datasim",
+        SaveData = "github_artifact",
+        gsm.datasim = list(
+          profile = "standard",
+          study_type = "standard",
+          snapshot_count = 1
+        ),
+        github_artifact = list(
+          path = output_dir,
+          artifact_name = "workr-hook-roundtrip",
+          run_id = "run-001",
+          include = c("loaded_val", "Raw_SUBJ", "dfSUBJ", "result"),
+          uploader = function(...) {
+            args <- list(...)
+            bundle_dir <<- args$bundle_dir
+            saved_state <<- args$lWorkflow$lData[c(
+              "loaded_val",
+              "Raw_SUBJ",
+              "dfSUBJ",
+              "result"
+            )]
+          }
+        )
+      )
+    )
+  })
+
+  expect_equal(first_result, 7)
+  expect_true(dir.exists(bundle_dir))
+
+  restored <- suppressMessages(RunWorkflow(
+    lWorkflow = workflow,
+    lData = list(existing = 1),
+    lConfig = list(
+      LoadData = "github_artifact",
+      github_artifact = list(
+        repo = "Gilead-BioStats/workr",
+        artifact_name = "workr-hook-roundtrip",
+        policy = "latest_success",
+        run_resolver = function(...) "run-001",
+        artifact_fetcher = function(...) bundle_dir
+      )
+    ),
+    bReturnResult = FALSE
+  ))
+
+  expect_equal(restored$lData$existing, 1)
+  expect_equal(restored$lData$loaded_val, saved_state$loaded_val)
+  expect_equal(restored$lData$result, saved_state$result)
+  expect_equal(restored$lData$Raw_SUBJ, saved_state$Raw_SUBJ)
+  expect_equal(restored$lData$dfSUBJ, saved_state$dfSUBJ)
+})

--- a/vignettes/load-save-hooks.Rmd
+++ b/vignettes/load-save-hooks.Rmd
@@ -266,3 +266,55 @@ lConfig <- list(
   )
 )
 ```
+
+# GitHub Actions artifact operations
+
+The built-in `"github_artifact"` providers support the operational cycle used in CI:
+
+1. Load inputs, for example with `LoadData = "gsm.datasim"`.
+2. Run the workflow steps.
+3. Save selected `lData` entries with `SaveData = "github_artifact"`.
+4. Restore the saved artifact in a later run with `LoadData = "github_artifact"`.
+
+The save provider writes a local bundle containing `manifest.yaml` and one `.rds` payload file per selected `lData` entry. If the bundle should be available to later GitHub Actions jobs, upload the bundle directory after `RunWorkflow()` completes, for example with `actions/upload-artifact`.
+
+```r
+lConfig <- list(
+  LoadData = "gsm.datasim",
+  SaveData = "github_artifact",
+  gsm.datasim = list(
+    profile = "standard",
+    study_type = "standard",
+    snapshot_count = 1
+  ),
+  github_artifact = list(
+    artifact_name = "workr-study-state",
+    include = c("Raw_SUBJ", "dfSUBJ", "result")
+  )
+)
+```
+
+A later run can restore that bundle by naming the repository and either an explicit `run_id` or a restore policy:
+
+```r
+lConfig <- list(
+  LoadData = "github_artifact",
+  github_artifact = list(
+    repo = "owner/repo",
+    artifact_name = "workr-study-state",
+    policy = "latest_success"
+  )
+)
+```
+
+Restoring artifacts uses the GitHub Actions API to list workflow runs, list artifacts for the selected run, and download the artifact bundle. In GitHub Actions, expose a token to R as `GH_TOKEN` or `GITHUB_PAT` and grant at least:
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+```
+
+For fine-grained personal access tokens, grant repository access plus **Actions: Read**.
+
+Common restore failures usually point to one of three setup issues: the token is missing or lacks `actions: read`, `artifact_name` or `repo` points at the wrong artifact, or the uploaded artifact did not contain the full bundle directory with `manifest.yaml` at its root.


### PR DESCRIPTION
## Overview

This PR is now stacked on PR #71 (`fix-59`) and keeps `fix-62` focused on the remaining hardening requested by issue #62.

- Adds an end-to-end hook roundtrip test covering `gsm.datasim` load, workflow execution, `github_artifact` save, and later artifact restore.
- Adds GitHub artifact restore auth guidance when GitHub API calls fail with authentication or permission errors, including the required `actions: read` permission.
- Folds the operator-facing GitHub Actions artifact runbook material into the existing `Load and Save Hooks` vignette instead of adding a separate vignette.

## Scope Notes

This PR no longer carries the broader `gsm.datasim` provider implementation, README example, standalone live example, or separate runbook article as its own review surface. Those remain in PR #71 where they belong.

Because this branch is stacked on `fix-59`, review should focus on the four #62 files changed here: artifact auth handling, the auth/roundtrip tests, and the added operations section in the existing hook vignette.

## Test Notes

Local focused validation:

```r
pkgload::load_all(export_all = FALSE)
testthat::test_file("tests/testthat/test-hook-roundtrip.R")
testthat::test_file("tests/testthat/test-github-artifact-providers.R")
```

Results:

- `tests/testthat/test-hook-roundtrip.R`: 7 passed
- `tests/testthat/test-github-artifact-providers.R`: 25 passed

## Connected Issues

- Closes #62
- Stacked on #71
