### PR TITLE
Fix mixed timestamp parsing in RunQuery()

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -127,7 +127,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
             (mapping$type != "timestamp" && !inherits(raw_vals, mapping$type))) {
             parsed <- map(raw_vals, ~ tryCatch(
               as.POSIXct(.x, tz = "UTC"),
-              error = function(e) NA_real_
+              error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01", tz = "UTC")
             ))
 
             parsed <- purrr::list_c(parsed) %>% as.POSIXct(origin = "1970-01-01", tz = "UTC")

--- a/tests/testthat/test-RunQuery.R
+++ b/tests/testthat/test-RunQuery.R
@@ -166,6 +166,37 @@ test_that("RunQuery parses invalid date/times correctly (#26)", {
   expect_true(all(is.na(result$Birthtime)))
 })
 
+test_that("RunQuery handles mixed valid and invalid timestamps", {
+  skip_if_not_installed("DBI")
+  skip_if_not_installed("duckdb")
+
+  df <- data.frame(
+    Name = c("John", "Jane"),
+    Birthtime = c("1990-01-01 06:47:00", "not a timestamp")
+  )
+  lColumnMapping <- list(
+    Name = list(type = "character"),
+    Birthtime = list(type = "timestamp")
+  )
+
+  query <- "SELECT * FROM df"
+
+  suppressWarnings(
+    suppressMessages(
+      result <- RunQuery(
+        query,
+        df,
+        bUseSchema = TRUE,
+        lColumnMapping = lColumnMapping
+      )
+    )
+  )
+
+  expect_equal(class(result$Birthtime), c("POSIXct", "POSIXt"))
+  expect_false(is.na(result$Birthtime[[1]]))
+  expect_true(is.na(result$Birthtime[[2]]))
+})
+
 test_that("RunQuery requires lColumnMapping when bUseSchema is TRUE (#26)", {
   df <- data.frame(x = 1:3)
   query <- "SELECT * FROM df"


### PR DESCRIPTION
## Summary

This PR collects the workr changes made since the `v1.0.0` release tag. The branch expands workflow discovery and execution ergonomics, formalizes configurable load/save hooks, adds GitHub Actions artifact-backed data providers, and hardens the GitHub/manifest automation used by snapshot and CI workflows.

## Changes since `v1.0.0`

### Workflow discovery and execution

- Added `ListWorkflows()` and `ListWorkflowNames()` for discovering workflow YAML files from package or local workflow directories.
- Extended `MakeWorkflowList()` with exact-name matching, recursive discovery controls, active/inactive filtering via `meta$Active`, required-field validation, workflow ID naming, and `meta$Priority` ordering.
- Added support for the singular `inst/workflow` package workflow directory while retaining compatibility with existing workflow-loading paths.
- Passed `lConfig` through `RunWorkflow()` and `RunWorkflows()` so workflow execution can use configured load/save behavior.
- Fixed mixed Date/POSIXct timestamp parsing in `RunQuery()` when schema enforcement is enabled.

### Load/save hooks and GitHub artifacts

- Added `register_load_provider()` and `register_save_provider()` for reusable named workflow data hooks.
- Added built-in `github_artifact` load and save providers for persisting workflow data as manifest-described RDS payloads in GitHub Actions artifacts.
- Added artifact restore support for explicit run IDs or latest successful workflow runs, configurable missing-artifact behavior, include/exclude key filters, custom upload/fetch hooks, and path traversal validation for downloaded bundles.
- Documented inline hooks, registered providers, and multi-workflow hook usage in a new Load and Save Hooks vignette.

### GitHub, manifests, and automation

- Migrated GitHub API helper behavior to `gh::gh()` and hardened package/ref resolution, snapshot helpers, and manifest workflow installation behavior.
- Simplified GitHub artifact helper internals and added mocked coverage for snapshot and artifact provider workflows.
- Updated GitHub Actions for R CMD check, manifest generation, pkgdown deployment, qcthat, test coverage, release automation, and workflow-template checks.

### Examples, docs, and tests

- Reorganized bundled example workflows and test fixtures under `workflow` and `_fixtures` directories, including active/inactive workflow examples and malformed workflow fixtures.
- Updated README, pkgdown configuration, generated documentation, and lifecycle assets for the expanded workflow and hook APIs.
- Added and expanded tests for workflow listing/loading, active workflow filtering, workflow execution, query schema parsing, load/save hook behavior, GitHub artifact providers, and snapshot helpers.

## Release notes

- Added a development NEWS entry summarizing the post-`v1.0.0` changes.

## Validation

- Branch includes new and expanded testthat coverage across workflow loading/execution, `RunQuery()` schema parsing, load/save hooks, GitHub artifact providers, and snapshot helpers.
- `NEWS.md` diagnostics are clean after adding the release-note snippet.