### PR TITLE
Use pointblank as the spec validation engine behind CheckSpec()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^[.]?air[.]toml$
 ^\.vscode$
 ^\.posit$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ workr.Rcheck/
 .DS_Store
 docs
 .posit
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: workr
 Title: Workflow Execution Helpers
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(
     person("Jeremy", "Wildfire", , "jwildfire@gilead.com", role = c("aut", "cre")),
     person("Zelos", "Zhu", , "zelos.zhu@atorus.com", role = "aut"),
@@ -32,6 +32,7 @@ Imports:
 Suggests:
     gsm.datasim,
     knitr,
+    pointblank,
     rmarkdown,
     shiny,
     testthat (>= 3.0.0),
@@ -41,7 +42,7 @@ Remotes:
 VignetteBuilder:
     knitr
 Config/Needs/website: admiral, arrow, cards, gt, gtsummary, sdtm.oak
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     rlang,
     yaml
 Suggests:
+    arrow,
     gsm.datasim,
     knitr,
     pointblank,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -25,18 +25,26 @@ export(register_save_provider)
 export(sum_step)
 export(write_rproject_toml)
 import(rlang)
-importFrom(dplyr,"%>%")
-importFrom(dplyr,select)
+importFrom(dplyr,
+  "%>%",
+  select
+)
 importFrom(glue,glue)
-importFrom(lifecycle,badge)
-importFrom(lifecycle,deprecated)
-importFrom(purrr,imap)
-importFrom(purrr,keep)
-importFrom(purrr,map)
-importFrom(purrr,map2)
-importFrom(purrr,map_chr)
-importFrom(purrr,map_dbl)
-importFrom(utils,capture.output)
-importFrom(utils,read.csv)
-importFrom(utils,str)
-importFrom(utils,write.csv)
+importFrom(lifecycle,
+  badge,
+  deprecated
+)
+importFrom(purrr,
+  imap,
+  keep,
+  map,
+  map2,
+  map_chr,
+  map_dbl
+)
+importFrom(utils,
+  capture.output,
+  read.csv,
+  str,
+  write.csv
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# workr (development version)
+
+* Workflows can now validate their input data before running any steps, via an
+  optional `spec` section in the workflow YAML (#91).
+
 # workr 1.1.0
 
 ## Highlights

--- a/R/ListWorkflows.R
+++ b/R/ListWorkflows.R
@@ -84,7 +84,11 @@ ListWorkflowNames <- function(
     full.names = TRUE,
     recursive = bRecursive
   )
-  yaml_files <- yaml_files[!basename(yaml_files) %in% c("_config.yaml", "_config.yml")]
+  yaml_files <- yaml_files[
+    !basename(yaml_files) %in% c("_config.yaml", "_config.yml")
+  ]
+  # `*_spec.yaml` files are pointblank data specs, not workflows (#91).
+  yaml_files <- yaml_files[!grepl("_spec\\.(yaml|yml)$", basename(yaml_files))]
   names(yaml_files) <- basename(yaml_files)
   yaml_files
 }

--- a/R/RunWorkflow.R
+++ b/R/RunWorkflow.R
@@ -99,8 +99,7 @@ RunWorkflow <- function(
       message = "Checking data against spec",
       cli_detail = "h3"
     )
-    # TODO: verify domain names in [ lData ] exist in [ lWorkflow$spec ]
-    CheckSpec(lData, lWorkflow$spec)
+    CheckSpec(lData, lWorkflow$spec, strPath = lWorkflow$path)
   } else {
     lWorkflow$spec <- NULL
     LogMessage(

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,14 +1,29 @@
+#' Emit a formatted log record
+#'
+#' The single point where log output actually reaches the console. Keeping this
+#' separate from `LogMessage()` gives tests a seam: mock `appender()` with
+#' `local_mocked_bindings()` to silence expected levels without wrapping every
+#' call in `suppressMessages()`.
+#'
+#' @param level Log level, e.g. `"info"` or `"warn"`.
+#' @param msg Already-formatted message text.
+#'
+#' @keywords internal
+#' @noRd
+appender <- function(level, msg) {
+  message("[", toupper(level), "] ", msg)
+}
+
 #' Internal message helper
 #'
 #' @keywords internal
 #' @noRd
 LogMessage <- function(level = "info", message, cli_detail = NULL) {
   msg <- glue::glue(message, .envir = parent.frame())
-  prefix <- toupper(level)
   if (!is.null(cli_detail)) {
     msg <- glue::glue("{msg}")
   }
-  message("[", prefix, "] ", msg)
+  appender(level, msg)
 }
 
 #' Resolve function namespaced or local
@@ -38,52 +53,246 @@ GetStrFunctionIfNamespaced <- function(strName) {
     return(get(strName, envir = parent.frame(), inherits = TRUE))
   }
 
+  # `inherits = TRUE` walks the namespace's parents -- imports, base, and the
+  # attached search path -- so base/attached functions like `read.csv` resolve
+  # here too, without needing an explicit namespace qualifier.
   if (exists(strName, envir = asNamespace("workr"), inherits = TRUE)) {
     return(get(strName, envir = asNamespace("workr"), inherits = TRUE))
-  }
-
-  # Fallback to the user search path so base/attached package functions
-  # like read.csv are available without explicit namespace qualification.
-  if (exists(strName, envir = .GlobalEnv, mode = "function", inherits = TRUE)) {
-    return(get(strName, envir = .GlobalEnv, mode = "function", inherits = TRUE))
   }
 
   stop(glue::glue("Function '{strName}' not found."))
 }
 
-#' Basic spec validation helper
+#' Classify a per-domain spec as legacy or pointblank-style
+#'
+#' The two dialects are structurally disjoint: a legacy domain spec is always a
+#' named list of column definitions, while a pointblank spec is either a path to
+#' a `*_spec.yaml` file or a mapping containing `steps`.
+#'
+#' An unrecognized shape is an error rather than a silent fallback to legacy --
+#' a malformed pointblank spec must never quietly degrade into "no validation".
 #'
 #' @keywords internal
 #' @noRd
-CheckSpec <- function(lData, lSpec) {
+.SpecDialect <- function(spec, domain) {
+  if (is.character(spec) && length(spec) == 1L) {
+    return("pointblank_file")
+  }
+
+  if (is.list(spec)) {
+    if ("steps" %in% names(spec)) {
+      return("pointblank_inline")
+    }
+    # A legacy spec is a named list; the historical `required_cols` / `required`
+    # / `columns` keys are also legacy.
+    if (length(spec) == 0L || !is.null(names(spec))) {
+      return("legacy")
+    }
+  }
+
+  stop(
+    glue::glue(
+      "Unrecognized spec format for domain '{domain}'. Expected a legacy column \\
+      mapping, a path to a pointblank spec file, or a mapping containing `steps`."
+    ),
+    call. = FALSE
+  )
+}
+
+#' Validate one domain against a legacy spec
+#'
+#' Preserves historical behavior exactly: column *existence* is checked, and any
+#' declared `type:` is deliberately ignored. Enforcing types here would newly
+#' fail workflows that pass today on unchanged data; migrate a spec to
+#' pointblank form to opt into type checking.
+#'
+#' The `_all: {required: true}` wildcard is deliberately permissive. It marks a
+#' domain as "needed, but not picky about its shape", so it asserts only that
+#' the table is non-empty -- it names no columns, so it can claim nothing about
+#' them. Use a pointblank spec where real column-level assertions are wanted.
+#'
+#' @keywords internal
+#' @noRd
+.CheckSpecLegacy <- function(data, spec, domain) {
+  required_cols <- NULL
+  if (is.list(spec)) {
+    required_cols <- spec$required_cols %||% spec$required %||% spec$columns
+  }
+
+  if (!is.null(required_cols)) {
+    missing_cols <- setdiff(required_cols, names(data))
+    if (length(missing_cols) > 0) {
+      stop(glue::glue(
+        "Missing required columns in '{domain}': {paste(missing_cols, collapse = ', ')}"
+      ))
+    }
+  }
+
+  wildcard <- .SpecWildcardRequired(spec)
+  if (wildcard) {
+    stop_if(
+      is.null(ncol(data)) || ncol(data) == 0L || nrow(data) == 0L,
+      "Required input '{domain}' is empty."
+    )
+  }
+
+  n_steps <- length(required_cols %||% character(0)) + as.integer(wildcard)
+
+  list(
+    domain = domain,
+    dialect = "legacy",
+    level = "pass",
+    passed = TRUE,
+    n_steps = n_steps,
+    n_failed_steps = 0L,
+    failed_steps = character(0),
+    agent = NULL
+  )
+}
+
+#' Is a legacy spec's `_all` wildcard set to required?
+#'
+#' @keywords internal
+#' @noRd
+.SpecWildcardRequired <- function(spec) {
+  if (!is.list(spec)) {
+    return(FALSE)
+  }
+  isTRUE(spec[["_all", exact = TRUE]]$required)
+}
+
+#' Resolve a spec file path, optionally relative to the workflow file
+#'
+#' @keywords internal
+#' @noRd
+.ResolveSpecPath <- function(spec, domain, strPath = NULL) {
+  path <- spec
+  if (!is.null(strPath) && !file.exists(path)) {
+    path <- file.path(dirname(strPath), spec)
+  }
+
+  stop_if(
+    !file.exists(path),
+    "Spec file for domain '{domain}' not found: {spec}"
+  )
+
+  path
+}
+
+#' Load a per-domain spec into its parsed pointblank form
+#'
+#' File-referenced and inline pointblank specs converge on the same
+#' representation here, so downstream code has a single path to handle.
+#'
+#' @keywords internal
+#' @noRd
+.LoadSpec <- function(spec, dialect, domain, strPath = NULL) {
+  if (identical(dialect, "pointblank_file")) {
+    return(yaml::read_yaml(.ResolveSpecPath(spec, domain, strPath)))
+  }
+  spec
+}
+
+#' Apply the spec failure contract to one domain's results
+#'
+#' `error` and `critical` abort the workflow; `warning` is logged and execution
+#' continues. See <https://github.com/Gilead-Public/workr/issues/91>.
+#'
+#' @keywords internal
+#' @noRd
+.EnforceSpecResult <- function(result) {
+  if (result$level %in% c("error", "critical")) {
+    stop(
+      glue::glue(
+        "Spec validation failed for '{result$domain}' at level '{result$level}': \\
+        {result$n_failed_steps} of {result$n_steps} step(s) failed \\
+        ({paste(unique(result$failed_steps), collapse = ', ')})."
+      ),
+      call. = FALSE
+    )
+  }
+
+  if (identical(result$level, "warning")) {
+    LogMessage(
+      level = "warn",
+      message = paste0(
+        "Spec validation warning for '",
+        result$domain,
+        "': ",
+        result$n_failed_steps,
+        " of ",
+        result$n_steps,
+        " step(s) failed."
+      )
+    )
+  }
+
+  invisible(result)
+}
+
+#' Validate a single domain against its spec
+#'
+#' Dispatches on dialect, then enforces the failure contract.
+#'
+#' @keywords internal
+#' @noRd
+.CheckSpecDomain <- function(data, spec, domain, strPath = NULL) {
+  dialect <- .SpecDialect(spec, domain)
+
+  if (identical(dialect, "legacy")) {
+    return(.CheckSpecLegacy(data, spec, domain))
+  }
+
+  spec <- .LoadSpec(spec, dialect, domain, strPath)
+  result <- .PbSummarize(.PbInterrogate(data, spec, domain), domain)
+  .EnforceSpecResult(result)
+
+  result
+}
+
+#' Spec validation helper
+#'
+#' Validates `lData` against `lSpec`, supporting both the legacy workr spec
+#' format and generic (Python-compatible) pointblank specs. See
+#' <https://github.com/Gilead-Public/workr/issues/91>.
+#'
+#' Failure contract: `error` and `critical` threshold breaches abort; `warning`
+#' is logged and execution continues. Legacy specs remain a hard stop.
+#'
+#' @param lData Named list of domain data frames.
+#' @param lSpec Named list mapping domain names to specs.
+#' @param strPath Optional path to the workflow file, used to resolve relative
+#'   spec file paths.
+#'
+#' @return Invisibly, a named list of per-domain validation results.
+#' @keywords internal
+#' @noRd
+CheckSpec <- function(lData, lSpec, strPath = NULL) {
   if (is.null(lSpec) || is.null(lData)) {
-    return(invisible(TRUE))
+    return(invisible(list()))
   }
 
   if (!is.list(lSpec) || length(lSpec) == 0) {
-    return(invisible(TRUE))
+    return(invisible(list()))
   }
 
-  for (domain in names(lSpec)) {
-    if (!domain %in% names(lData)) {
-      stop(glue::glue("Spec-declared input '{domain}' not found in lData."))
-    }
+  domains <- names(lSpec)
 
-    spec <- lSpec[[domain]]
-    required_cols <- NULL
-    if (is.list(spec)) {
-      required_cols <- spec$required_cols %||% spec$required %||% spec$columns
-    }
+  missing_domains <- setdiff(domains, names(lData))
+  stop_if(
+    length(missing_domains) > 0,
+    "Spec-declared input '{missing_domains[[1]]}' not found in lData."
+  )
 
-    if (!is.null(required_cols)) {
-      missing_cols <- setdiff(required_cols, names(lData[[domain]]))
-      if (length(missing_cols) > 0) {
-        stop(glue::glue("Missing required columns in '{domain}': {paste(missing_cols, collapse = ', ')}"))
-      }
+  results <- lapply(
+    domains,
+    function(domain) {
+      .CheckSpecDomain(lData[[domain]], lSpec[[domain]], domain, strPath)
     }
-  }
+  )
+  names(results) <- domains
 
-  invisible(TRUE)
+  invisible(results)
 }
 
 `%||%` <- function(x, y) {

--- a/R/internal.R
+++ b/R/internal.R
@@ -83,6 +83,23 @@ GetStrFunctionIfNamespaced <- function(strName) {
     if ("steps" %in% names(spec)) {
       return("pointblank_inline")
     }
+    # A mapping carrying pointblank-only top-level keys but no `steps` is a
+    # malformed pointblank spec, not a legacy one. Falling through to legacy
+    # here would validate nothing at all.
+    pb_markers <- intersect(
+      names(spec),
+      c("tbl", "tbl_name", "label", "lang", "locale", "thresholds", "actions")
+    )
+    if (length(pb_markers) > 0L) {
+      stop(
+        glue::glue(
+          "Spec for domain '{domain}' looks like a pointblank spec \\
+          ({paste(pb_markers, collapse = ', ')}) but has no `steps`. \\
+          Add a `steps:` list, or remove these keys to use a legacy spec."
+        ),
+        call. = FALSE
+      )
+    }
     # A legacy spec is a named list; the historical `required_cols` / `required`
     # / `columns` keys are also legacy.
     if (length(spec) == 0L || !is.null(names(spec))) {

--- a/R/internal.R
+++ b/R/internal.R
@@ -88,7 +88,15 @@ GetStrFunctionIfNamespaced <- function(strName) {
     # here would validate nothing at all.
     pb_markers <- intersect(
       names(spec),
-      c("tbl", "tbl_name", "label", "lang", "locale", "thresholds", "actions")
+      c(
+        "tbl",
+        "tbl_name",
+        "label",
+        "lang",
+        "locale",
+        "thresholds",
+        "actions"
+      )
     )
     if (length(pb_markers) > 0L) {
       stop(
@@ -249,19 +257,28 @@ GetStrFunctionIfNamespaced <- function(strName) {
 
 #' Validate a single domain against its spec
 #'
-#' Dispatches on dialect, then enforces the failure contract.
+#' Dispatches on dialect, then enforces the failure contract. For pointblank
+#' specs the spec's `tbl:` key names the object to validate; it is resolved in
+#' `lData`, which is the execution environment for a workflow's specs.
 #'
 #' @keywords internal
 #' @noRd
-.CheckSpecDomain <- function(data, spec, domain, strPath = NULL) {
+.CheckSpecDomain <- function(lData, spec, domain, strPath = NULL) {
   dialect <- .SpecDialect(spec, domain)
 
   if (identical(dialect, "legacy")) {
-    return(.CheckSpecLegacy(data, spec, domain))
+    return(.CheckSpecLegacy(lData[[domain]], spec, domain))
   }
 
   spec <- .LoadSpec(spec, dialect, domain, strPath)
-  result <- .PbSummarize(.PbInterrogate(data, spec, domain), domain)
+
+  tbl <- .SpecTbl(spec, domain)
+  stop_if(
+    !tbl %in% names(lData),
+    "Spec for domain '{domain}' names table '{tbl}', which is not in lData."
+  )
+
+  result <- .PbSummarize(.PbInterrogate(lData[[tbl]], spec, domain), domain)
   .EnforceSpecResult(result)
 
   result
@@ -304,7 +321,7 @@ CheckSpec <- function(lData, lSpec, strPath = NULL) {
   results <- lapply(
     domains,
     function(domain) {
-      .CheckSpecDomain(lData[[domain]], lSpec[[domain]], domain, strPath)
+      .CheckSpecDomain(lData, lSpec[[domain]], domain, strPath)
     }
   )
   names(results) <- domains

--- a/R/spec-pointblank.R
+++ b/R/spec-pointblank.R
@@ -142,12 +142,23 @@
   if (is.character(step) && length(step) == 1L) {
     method <- step
     args <- list()
-  } else if (is.list(step) && length(step) >= 1L && !is.null(names(step))) {
+  } else if (is.list(step) && length(step) == 1L && !is.null(names(step))) {
     method <- names(step)[[1L]]
     args <- step[[1L]] %||% list()
     if (!is.list(args)) {
       args <- as.list(args)
     }
+  } else if (is.list(step) && length(step) > 1L && !is.null(names(step))) {
+    # Silently using only the first key here would drop the remaining
+    # validations without any signal.
+    stop(
+      "Each entry of `steps` must be a single-key mapping; got ",
+      length(step),
+      " keys: ",
+      paste(names(step), collapse = ", "),
+      ". Split these into separate `steps` entries.",
+      call. = FALSE
+    )
   } else {
     stop(
       "Each entry of `steps` must be a validation method name or a single-key mapping.",

--- a/R/spec-pointblank.R
+++ b/R/spec-pointblank.R
@@ -1,0 +1,300 @@
+# Translation layer between generic (Python-form) pointblank YAML specs and the
+# R pointblank package's public API.
+#
+# Why this exists: R pointblank's YAML reader silently discards every top-level
+# key it does not recognize -- including `thresholds:`. A spec authored in Python
+# form would therefore interrogate in R with no severity levels at all and report
+# success, which is the worst possible failure mode for a validation pipeline.
+# Driving the public API directly (create_agent + do.call per step) lets us
+# control that, so we can warn on keys that would otherwise vanish.
+#
+# See https://github.com/Gilead-Public/workr/issues/91
+
+# Python-form -> R-form renames. R errors loudly on these, so they must be
+# translated rather than passed through.
+.pb_method_renames <- c(
+  col_vals_le = "col_vals_lte",
+  col_vals_ge = "col_vals_gte"
+)
+
+.pb_arg_renames <- c(pattern = "regex")
+
+# Python severity names -> action_levels() argument names. The `*_fraction`
+# spellings are the YAML serialization names, not function arguments.
+.pb_threshold_renames <- c(
+  warning = "warn_at",
+  error = "stop_at",
+  critical = "notify_at",
+  warn_fraction = "warn_at",
+  stop_fraction = "stop_at",
+  notify_fraction = "notify_at"
+)
+
+# Top-level keys we knowingly accept. Anything outside this set is warned about.
+# The Python-only governance keys are inert in R but recognized so we stay quiet.
+.pb_known_top_keys <- c(
+  "tbl",
+  "tbl_name",
+  "label",
+  "lang",
+  "locale",
+  "thresholds",
+  "actions",
+  "steps",
+  "df_library",
+  "owner",
+  "consumers",
+  "version",
+  "brief",
+  "final_actions",
+  "missing_specs",
+  "reference"
+)
+
+# The cross-language safe subset. Methods outside this set may exist in R but are
+# not guaranteed to round-trip to Python pointblank.
+.pb_portable_methods <- c(
+  "col_exists",
+  "col_vals_gt",
+  "col_vals_gte",
+  "col_vals_lt",
+  "col_vals_lte",
+  "col_vals_equal",
+  "col_vals_not_equal",
+  "col_vals_between",
+  "col_vals_not_between",
+  "col_vals_in_set",
+  "col_vals_not_in_set",
+  "col_vals_null",
+  "col_vals_not_null",
+  "col_vals_regex",
+  "rows_distinct",
+  "rows_complete",
+  "col_schema_match",
+  "col_is_character",
+  "col_is_numeric",
+  "col_is_integer",
+  "col_is_logical",
+  "col_is_date",
+  "col_is_posix",
+  "col_is_factor"
+)
+
+#' Convert a thresholds mapping into a named list of `action_levels()` arguments
+#'
+#' Returns a plain list rather than an `action_levels` object so that step-level
+#' thresholds can be merged over global ones before construction.
+#'
+#' @keywords internal
+#' @noRd
+.PbThresholdArgs <- function(x) {
+  if (is.null(x) || !length(x)) {
+    return(list())
+  }
+
+  nms <- names(x)
+  if (is.null(nms)) {
+    stop(
+      "`thresholds` must be a named mapping (e.g. `warning: 0.1`).",
+      call. = FALSE
+    )
+  }
+
+  renamed <- ifelse(
+    nms %in% names(.pb_threshold_renames),
+    .pb_threshold_renames[nms],
+    nms
+  )
+  names(x) <- renamed
+
+  unknown <- setdiff(renamed, unname(.pb_threshold_renames))
+  if (length(unknown)) {
+    warning(
+      "Ignoring unrecognized threshold level(s): ",
+      paste(unknown, collapse = ", "),
+      ". Valid levels are: warning, error, critical.",
+      call. = FALSE
+    )
+  }
+
+  as.list(x[renamed %in% unname(.pb_threshold_renames)])
+}
+
+#' Build an `action_levels` object from a list of arguments
+#'
+#' @keywords internal
+#' @noRd
+.PbActionLevels <- function(args) {
+  if (!length(args)) {
+    return(NULL)
+  }
+  do.call(pointblank::action_levels, args)
+}
+
+#' Normalize a single YAML step into a method name and argument list
+#'
+#' Handles bare-string steps (`- rows_distinct`), which R pointblank's own YAML
+#' reader rejects with "argument is of length zero".
+#'
+#' @keywords internal
+#' @noRd
+.PbTranslateStep <- function(step, global_thresholds = list()) {
+  if (is.character(step) && length(step) == 1L) {
+    method <- step
+    args <- list()
+  } else if (is.list(step) && length(step) >= 1L && !is.null(names(step))) {
+    method <- names(step)[[1L]]
+    args <- step[[1L]] %||% list()
+    if (!is.list(args)) {
+      args <- as.list(args)
+    }
+  } else {
+    stop(
+      "Each entry of `steps` must be a validation method name or a single-key mapping.",
+      call. = FALSE
+    )
+  }
+
+  if (method %in% names(.pb_method_renames)) {
+    method <- unname(.pb_method_renames[[method]])
+  }
+
+  if (!method %in% .pb_portable_methods) {
+    warning(
+      "Validation method '",
+      method,
+      "' is outside the cross-language portable ",
+      "subset and may not behave identically in Python pointblank.",
+      call. = FALSE
+    )
+  }
+
+  if (!length(args)) {
+    args <- list()
+  } else if (!is.null(names(args))) {
+    nms <- names(args)
+    names(args) <- ifelse(
+      nms %in% names(.pb_arg_renames),
+      .pb_arg_renames[nms],
+      nms
+    )
+  }
+
+  # Step-level thresholds are MERGED over the global ones rather than replacing
+  # them. Verified on pointblank 0.12.4: passing a step-level `actions` replaces
+  # the global action_levels outright, leaving unspecified levels as NA -- so a
+  # step that tightens only `warning` would silently discard the global `error`.
+  # Merging is the safer reading.
+  # TODO(#91): confirm Python pointblank's precedence before relying on this.
+  if (!is.null(args$thresholds)) {
+    merged <- utils::modifyList(
+      global_thresholds,
+      .PbThresholdArgs(args$thresholds)
+    )
+    args$thresholds <- NULL
+    args$actions <- .PbActionLevels(merged)
+  }
+
+  list(method = method, args = args)
+}
+
+#' Interrogate a data frame against a generic pointblank spec
+#'
+#' Ignores any `tbl:` field in the spec and injects `data` directly. `tbl:` is an
+#' R formula in R pointblank and a lambda in Python, so it is the one field that
+#' provably cannot round-trip between the two languages.
+#'
+#' @return A pointblank agent that has been interrogated.
+#' @keywords internal
+#' @noRd
+.PbInterrogate <- function(data, spec, domain = NULL) {
+  rlang::check_installed(
+    "pointblank",
+    reason = "to validate data against pointblank-style specs."
+  )
+
+  unknown <- setdiff(names(spec), .pb_known_top_keys)
+  if (length(unknown)) {
+    warning(
+      "Ignoring unrecognized top-level spec key(s)",
+      if (!is.null(domain)) paste0(" in '", domain, "'") else "",
+      ": ",
+      paste(unknown, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  # Use [[ ]] with exact = TRUE throughout: `spec$tbl` partial-matches `tbl_name`.
+  if (!is.null(spec[["tbl", exact = TRUE]])) {
+    LogMessage(
+      level = "info",
+      message = "Ignoring `tbl` in spec; validating data supplied by the workflow."
+    )
+  }
+
+  global_thresholds <- .PbThresholdArgs(
+    spec[["thresholds", exact = TRUE]] %||% spec[["actions", exact = TRUE]]
+  )
+
+  agent <- pointblank::create_agent(
+    tbl = data,
+    tbl_name = spec[["tbl_name", exact = TRUE]] %||% domain %||% "data",
+    label = spec[["label", exact = TRUE]],
+    actions = .PbActionLevels(global_thresholds)
+  )
+
+  for (step in spec[["steps", exact = TRUE]]) {
+    translated <- .PbTranslateStep(step, global_thresholds)
+    fn <- tryCatch(
+      getExportedValue("pointblank", translated$method),
+      error = function(e) {
+        stop(
+          "Unknown pointblank validation method: '",
+          translated$method,
+          "'.",
+          call. = FALSE
+        )
+      }
+    )
+    agent <- do.call(fn, c(list(agent), translated$args))
+  }
+
+  # Interrogation progress is pointblank's own console chatter; workr reports
+  # results through its own logging.
+  suppressMessages(pointblank::interrogate(agent))
+}
+
+#' Summarize an interrogated agent into a tidy result
+#'
+#' @keywords internal
+#' @noRd
+.PbSummarize <- function(agent, domain) {
+  vs <- agent$validation_set
+
+  # `notify` is NA when no threshold was set for that level; treat NA as "not
+  # breached" so an unset level never aborts a workflow.
+  breached <- function(x) isTRUE(any(x, na.rm = TRUE))
+
+  level <- if (breached(vs$notify)) {
+    "critical"
+  } else if (breached(vs$stop)) {
+    "error"
+  } else if (breached(vs$warn)) {
+    "warning"
+  } else {
+    "pass"
+  }
+
+  failed <- vs[!vs$all_passed %in% TRUE, , drop = FALSE]
+
+  list(
+    domain = domain,
+    dialect = "pointblank",
+    level = level,
+    passed = level == "pass",
+    n_steps = nrow(vs),
+    n_failed_steps = nrow(failed),
+    failed_steps = failed$assertion_type,
+    agent = agent
+  )
+}

--- a/R/spec-pointblank.R
+++ b/R/spec-pointblank.R
@@ -209,11 +209,31 @@
   list(method = method, args = args)
 }
 
+#' The table name declared by a pointblank spec
+#'
+#' `tbl:` names an object in the execution environment -- for workr, an element
+#' of `lData`. A leading `~` is accepted so that specs written in R pointblank's
+#' formula form (`tbl: ~ Raw_AE`) still resolve.
+#'
+#' Uses `[[ exact = TRUE ]]` because `spec$tbl` would partial-match `tbl_name`.
+#'
+#' @keywords internal
+#' @noRd
+.SpecTbl <- function(spec, domain = NULL) {
+  tbl <- spec[["tbl", exact = TRUE]]
+  if (is.null(tbl) || !is.character(tbl) || length(tbl) != 1L) {
+    return(domain %||% "data")
+  }
+  trimws(sub("^\\s*~", "", tbl))
+}
+
 #' Interrogate a data frame against a generic pointblank spec
 #'
-#' Ignores any `tbl:` field in the spec and injects `data` directly. `tbl:` is an
-#' R formula in R pointblank and a lambda in Python, so it is the one field that
-#' provably cannot round-trip between the two languages.
+#' `data` has already been resolved from the spec's `tbl:` name by
+#' `.CheckSpecDomain()`; this function only labels and runs the steps. The
+#' agent's `tbl_name` is display metadata, taken from the spec's optional
+#' `tbl_name:` field and falling back to the domain -- without it pointblank
+#' would label the report "data", after this function's own argument name.
 #'
 #' @return A pointblank agent that has been interrogated.
 #' @keywords internal
@@ -235,21 +255,13 @@
     )
   }
 
-  # Use [[ ]] with exact = TRUE throughout: `spec$tbl` partial-matches `tbl_name`.
-  if (!is.null(spec[["tbl", exact = TRUE]])) {
-    LogMessage(
-      level = "info",
-      message = "Ignoring `tbl` in spec; validating data supplied by the workflow."
-    )
-  }
-
   global_thresholds <- .PbThresholdArgs(
     spec[["thresholds", exact = TRUE]] %||% spec[["actions", exact = TRUE]]
   )
 
   agent <- pointblank::create_agent(
     tbl = data,
-    tbl_name = spec[["tbl_name", exact = TRUE]] %||% domain %||% "data",
+    tbl_name = spec[["tbl_name", exact = TRUE]] %||% domain,
     label = spec[["label", exact = TRUE]],
     actions = .PbActionLevels(global_thresholds)
   )

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,6 +24,8 @@ navbar:
         href: articles/Overview.html
       - text: "Load and Save Hooks"
         href: articles/load-save-hooks.html
+      - text: "Validating Workflow Inputs"
+        href: articles/validating-workflow-inputs.html
       - text: "Pharmaverse Case Study"
         href: articles/Pharmaverse.html
       - text: "Cookbook: sdtm.oak"

--- a/inst/example_workflows/03_KRI/AE.yaml
+++ b/inst/example_workflows/03_KRI/AE.yaml
@@ -4,29 +4,7 @@ meta:
   Description: Adverse Event Data Mapping
   Priority: 1
 spec:
- Raw_AE:
-    studyid:
-      type: character
-    subjid:
-      type: character
-    aeser:
-      type: character
-    aest_dt:
-      type: Date
-    aeen_dt:
-      type: Date
-    mdrpt_nsv:
-      type: character
-    mdrsoc_nsv:
-      type: character
-    aetoxgr:
-      type: character
-    aeongo:
-      type: character
-    aerel:
-      type: character
-    mincreated_dts:
-      type: timestamp
+  Raw_AE: AE_Raw_AE_spec.yaml
 steps:
   - output: Mapped_AE
     name: =

--- a/inst/example_workflows/03_KRI/AE_Raw_AE_spec.yaml
+++ b/inst/example_workflows/03_KRI/AE_Raw_AE_spec.yaml
@@ -1,9 +1,4 @@
-# Validation spec for the raw AE domain.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-tbl_name: Raw_AE
+tbl: Raw_AE
 label: Raw AE mapping spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/03_KRI/AE_Raw_AE_spec.yaml
+++ b/inst/example_workflows/03_KRI/AE_Raw_AE_spec.yaml
@@ -1,0 +1,20 @@
+# Validation spec for the raw AE domain.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+tbl_name: Raw_AE
+label: Raw AE mapping spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [studyid, subjid, aeser, aest_dt, aeen_dt, mdrpt_nsv,
+                mdrsoc_nsv, aetoxgr, aeongo, aerel, mincreated_dts]
+  - col_is_character:
+      columns: [studyid, subjid, aeser, mdrpt_nsv, mdrsoc_nsv, aetoxgr,
+                aeongo, aerel]
+  - col_is_date:
+      columns: [aest_dt, aeen_dt]
+  - col_is_posix:
+      columns: [mincreated_dts]

--- a/inst/example_workflows/03_KRI/SUBJ.yaml
+++ b/inst/example_workflows/03_KRI/SUBJ.yaml
@@ -4,38 +4,10 @@ meta:
   Description: Subject Data Mapping
   Priority: 1
 spec:
-  Raw_SUBJ:
-    studyid:
-      type: character
-    invid:
-      type: character
-    country:
-      type: character
-    subjid:
-      type: character
-    subject_nsv:
-      type: character
-    enrollyn:
-      type: character
-    timeonstudy:
-      type: integer
-    firstparticipantdate:
-      type: Date
-    firstdosedate:
-      type: Date
-    timeontreatment:
-      type: numeric
-    agerep:
-      type: character
-    sex:
-      type: character
-    race:
-      type: character
-    mincreated_dts:
-      type: timestamp
+  Raw_SUBJ: SUBJ_Raw_SUBJ_spec.yaml
 steps:
   - output: Mapped_SUBJ
-    name: gsm.core::RunQuery
+    name: workr::RunQuery
     params:
       df: Raw_SUBJ
       strQuery: "SELECT * FROM df WHERE enrollyn == 'Y'"

--- a/inst/example_workflows/03_KRI/SUBJ_Raw_SUBJ_spec.yaml
+++ b/inst/example_workflows/03_KRI/SUBJ_Raw_SUBJ_spec.yaml
@@ -1,9 +1,4 @@
-# Validation spec for the raw SUBJ domain.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-tbl_name: Raw_SUBJ
+tbl: Raw_SUBJ
 label: Raw SUBJ mapping spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/03_KRI/SUBJ_Raw_SUBJ_spec.yaml
+++ b/inst/example_workflows/03_KRI/SUBJ_Raw_SUBJ_spec.yaml
@@ -1,0 +1,27 @@
+# Validation spec for the raw SUBJ domain.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+tbl_name: Raw_SUBJ
+label: Raw SUBJ mapping spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [studyid, invid, country, subjid, subject_nsv, enrollyn,
+                timeonstudy, firstparticipantdate, firstdosedate,
+                timeontreatment, agerep, sex, race, mincreated_dts]
+  - col_is_character:
+      columns: [studyid, invid, country, subjid, subject_nsv, enrollyn,
+                agerep, sex, race]
+  # Use col_is_integer, not col_is_numeric: in R, col_is_numeric tests for
+  # double and rejects integer columns.
+  - col_is_integer:
+      columns: [timeonstudy]
+  - col_is_numeric:
+      columns: [timeontreatment]
+  - col_is_date:
+      columns: [firstparticipantdate, firstdosedate]
+  - col_is_posix:
+      columns: [mincreated_dts]

--- a/inst/example_workflows/03_KRI/kri0001.yaml
+++ b/inst/example_workflows/03_KRI/kri0001.yaml
@@ -12,16 +12,8 @@ meta:
   Threshold: -2,-1,2,3
   Priority: 2
 spec:
-  Mapped_AE:
-    subjid:
-      type: character
-  Mapped_SUBJ:
-    subjid:
-      type: character
-    invid:
-      type: character
-    timeonstudy:
-      type: integer
+  Mapped_AE: kri0001_Mapped_AE_spec.yaml
+  Mapped_SUBJ: kri0001_Mapped_SUBJ_spec.yaml
 steps:
   - output: vThreshold
     name: gsm.core::ParseThreshold
@@ -63,7 +55,7 @@ steps:
     params:
       dfFlagged: Analysis_Flagged
   - output: Flag_Distribution
-    name: gsm.core::RunQuery
+    name: workr::RunQuery
     params:
       df: Analysis_Summary
       strQuery: >

--- a/inst/example_workflows/03_KRI/kri0001_Mapped_AE_spec.yaml
+++ b/inst/example_workflows/03_KRI/kri0001_Mapped_AE_spec.yaml
@@ -1,0 +1,17 @@
+# Validation spec for the mapped AE domain used by the kri0001 analysis.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+#
+# This validates the output of the AE mapping workflow, so it asserts only the
+# columns the analysis reads.
+tbl_name: Mapped_AE
+label: Mapped AE analysis input spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [subjid]
+  - col_is_character:
+      columns: [subjid]

--- a/inst/example_workflows/03_KRI/kri0001_Mapped_AE_spec.yaml
+++ b/inst/example_workflows/03_KRI/kri0001_Mapped_AE_spec.yaml
@@ -1,12 +1,4 @@
-# Validation spec for the mapped AE domain used by the kri0001 analysis.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-#
-# This validates the output of the AE mapping workflow, so it asserts only the
-# columns the analysis reads.
-tbl_name: Mapped_AE
+tbl: Mapped_AE
 label: Mapped AE analysis input spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/03_KRI/kri0001_Mapped_SUBJ_spec.yaml
+++ b/inst/example_workflows/03_KRI/kri0001_Mapped_SUBJ_spec.yaml
@@ -1,12 +1,4 @@
-# Validation spec for the mapped SUBJ domain used by the kri0001 analysis.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-#
-# This validates the output of the SUBJ mapping workflow, so it asserts only
-# the columns the analysis reads.
-tbl_name: Mapped_SUBJ
+tbl: Mapped_SUBJ
 label: Mapped SUBJ analysis input spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/03_KRI/kri0001_Mapped_SUBJ_spec.yaml
+++ b/inst/example_workflows/03_KRI/kri0001_Mapped_SUBJ_spec.yaml
@@ -1,0 +1,21 @@
+# Validation spec for the mapped SUBJ domain used by the kri0001 analysis.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+#
+# This validates the output of the SUBJ mapping workflow, so it asserts only
+# the columns the analysis reads.
+tbl_name: Mapped_SUBJ
+label: Mapped SUBJ analysis input spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [subjid, invid, timeonstudy]
+  - col_is_character:
+      columns: [subjid, invid]
+  # timeonstudy is the rate denominator and stays integer through the mapping
+  # query. Use col_is_integer: in R, col_is_numeric rejects integer columns.
+  - col_is_integer:
+      columns: [timeonstudy]

--- a/inst/example_workflows/04_Example_RAW_TO_SDTM/DM.yaml
+++ b/inst/example_workflows/04_Example_RAW_TO_SDTM/DM.yaml
@@ -4,11 +4,7 @@ meta:
   Description: Transform Raw DM to SDTM DM
   Priority: 1
 spec:
-  dm_raw:
-    STUDYID:
-      type: character
-    USUBJID:
-      type: character
+  dm_raw: DM_dm_raw_spec.yaml
 steps:
   - output: dm
     name: workr::RunQuery

--- a/inst/example_workflows/04_Example_RAW_TO_SDTM/DM_dm_raw_spec.yaml
+++ b/inst/example_workflows/04_Example_RAW_TO_SDTM/DM_dm_raw_spec.yaml
@@ -1,0 +1,19 @@
+# Validation spec for the raw DM domain.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+tbl_name: dm_raw
+label: Raw DM ingestion spec
+thresholds:
+  warning: 0.01
+  error: 0.05
+steps:
+  - col_exists:
+      columns: [STUDYID, USUBJID]
+  - col_is_character:
+      columns: [STUDYID, USUBJID]
+  - col_vals_not_null:
+      columns: [STUDYID, USUBJID]
+  - rows_distinct:
+      columns: [USUBJID]

--- a/inst/example_workflows/04_Example_RAW_TO_SDTM/DM_dm_raw_spec.yaml
+++ b/inst/example_workflows/04_Example_RAW_TO_SDTM/DM_dm_raw_spec.yaml
@@ -1,9 +1,4 @@
-# Validation spec for the raw DM domain.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-tbl_name: dm_raw
+tbl: dm_raw
 label: Raw DM ingestion spec
 thresholds:
   warning: 0.01

--- a/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS.yaml
+++ b/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS.yaml
@@ -4,12 +4,8 @@ meta:
   Description: Create Basic ADVS
   Priority: 1
 spec:
-  SDTM_DM:
-    _all:
-      required: true
-  SDTM_VS:
-    _all:
-      required: true
+  SDTM_DM: ADVS_SDTM_DM_spec.yaml
+  SDTM_VS: ADVS_SDTM_VS_spec.yaml
 steps:
   - output: initial_advs
     name: admiral::derive_vars_merged

--- a/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_DM_spec.yaml
+++ b/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_DM_spec.yaml
@@ -1,0 +1,20 @@
+# Validation spec for the SDTM DM domain.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+tbl_name: SDTM_DM
+label: SDTM DM source spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [STUDYID, USUBJID, TRT01A]
+  - col_is_character:
+      columns: [STUDYID, USUBJID, TRT01A]
+  # STUDYID and USUBJID are the join keys used to merge treatment onto vitals.
+  # A null or duplicate key would silently drop or fan out rows.
+  - col_vals_not_null:
+      columns: [STUDYID, USUBJID]
+  - rows_distinct:
+      columns: [STUDYID, USUBJID]

--- a/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_DM_spec.yaml
+++ b/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_DM_spec.yaml
@@ -1,9 +1,4 @@
-# Validation spec for the SDTM DM domain.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-tbl_name: SDTM_DM
+tbl: SDTM_DM
 label: SDTM DM source spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_VS_spec.yaml
+++ b/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_VS_spec.yaml
@@ -1,12 +1,4 @@
-# Validation spec for the SDTM VS domain.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-#
-# Scoped to the columns the ADVS derivation reads: the merge keys, the
-# parameter/result pair, and the grouping variables.
-tbl_name: SDTM_VS
+tbl: SDTM_VS
 label: SDTM VS source spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_VS_spec.yaml
+++ b/inst/example_workflows/05_Example_SDTM_TO_ADAM/ADVS_SDTM_VS_spec.yaml
@@ -1,0 +1,31 @@
+# Validation spec for the SDTM VS domain.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+#
+# Scoped to the columns the ADVS derivation reads: the merge keys, the
+# parameter/result pair, and the grouping variables.
+tbl_name: SDTM_VS
+label: SDTM VS source spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [STUDYID, USUBJID, VSTESTCD, VSORRES, VSORRESU, VSDTC,
+                VISIT, VISITNUM, VSTPT, VSTPTNUM]
+  - col_is_character:
+      columns: [STUDYID, USUBJID, VSTESTCD, VSORRESU, VISIT, VISITNUM,
+                VSTPT, VSTPTNUM]
+  - col_is_numeric:
+      columns: [VSORRES]
+  # VSDTC gets an existence check but no type check. It holds ISO 8601 date
+  # strings, and when read from Parquet it arrives as character storage
+  # carrying an `iso8601` class attribute -- which satisfies neither
+  # col_is_character nor col_is_date, since both test the class.
+  - col_exists:
+      columns: [VSDTC]
+  # Measurement columns are legitimately missing for some records, so only the
+  # identifiers are asserted non-null.
+  - col_vals_not_null:
+      columns: [STUDYID, USUBJID, VSTESTCD]

--- a/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1.yaml
+++ b/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1.yaml
@@ -4,9 +4,7 @@ meta:
   Description: Create Basic Work Product/Report which can modularize the tables included
   Priority: 1
 spec:
-  ADVS:
-    _all:
-      required: true
+  ADVS: WorkProduct1_ADVS_spec.yaml
 steps:
   - output: lParams
     name: list

--- a/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1_ADVS_spec.yaml
+++ b/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1_ADVS_spec.yaml
@@ -1,0 +1,23 @@
+# Validation spec for the ADaM ADVS dataset used by the work product report.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+#
+# The full data frame is passed to the report template, so this asserts the
+# analysis columns a vital-signs table depends on.
+tbl_name: ADVS
+label: ADaM ADVS reporting input spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [STUDYID, USUBJID, TRT01A, PARAMCD, AVAL, VISIT, VSTPT]
+  - col_is_character:
+      columns: [STUDYID, USUBJID, TRT01A, PARAMCD, VISIT, VSTPT]
+  - col_is_numeric:
+      columns: [AVAL]
+  # AVAL is legitimately missing for some records, so only the identifiers are
+  # asserted non-null.
+  - col_vals_not_null:
+      columns: [STUDYID, USUBJID, PARAMCD]

--- a/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1_ADVS_spec.yaml
+++ b/inst/example_workflows/06_Example_ADAM_TO_TFL/WorkProduct1_ADVS_spec.yaml
@@ -1,12 +1,4 @@
-# Validation spec for the ADaM ADVS dataset used by the work product report.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-#
-# The full data frame is passed to the report template, so this asserts the
-# analysis columns a vital-signs table depends on.
-tbl_name: ADVS
+tbl: ADVS
 label: ADaM ADVS reporting input spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure.yaml
+++ b/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure.yaml
@@ -4,9 +4,7 @@ meta:
   Description: Create table 1 ARS
   Priority: 1
 spec:
-  ADVS:
-    _all:
-      required: true
+  ADVS: table_mean_arterial_pressure_ADVS_spec.yaml
 steps:
   - output: predose_visit1_map
     name: workr::RunQuery

--- a/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure_ADVS_spec.yaml
+++ b/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure_ADVS_spec.yaml
@@ -1,12 +1,4 @@
-# Validation spec for the ADaM ADVS dataset used by the ARS summary table.
-#
-# Written in the portable pointblank YAML dialect, so the same file can be read
-# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
-# the data frame, and this file only describes what must be true of it.
-#
-# Scoped to the columns the mean arterial pressure summary reads: the three
-# filter keys and the summarized value.
-tbl_name: ADVS
+tbl: ADVS
 label: ADaM ADVS ARS table input spec
 thresholds:
   error: 0.01

--- a/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure_ADVS_spec.yaml
+++ b/inst/example_workflows/07_Example_ADAM_TO_ARS/table_mean_arterial_pressure_ADVS_spec.yaml
@@ -1,0 +1,23 @@
+# Validation spec for the ADaM ADVS dataset used by the ARS summary table.
+#
+# Written in the portable pointblank YAML dialect, so the same file can be read
+# by both R and Python pointblank. There is no `tbl:` key: the workflow supplies
+# the data frame, and this file only describes what must be true of it.
+#
+# Scoped to the columns the mean arterial pressure summary reads: the three
+# filter keys and the summarized value.
+tbl_name: ADVS
+label: ADaM ADVS ARS table input spec
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [PARAMCD, VISIT, VSTPT, AVAL]
+  - col_is_character:
+      columns: [PARAMCD, VISIT, VSTPT]
+  - col_is_numeric:
+      columns: [AVAL]
+  # The workflow filters on PARAMCD == 'MAP'. A null here would quietly drop a
+  # record from the summary rather than raising anything.
+  - col_vals_not_null:
+      columns: [PARAMCD]

--- a/man/workr-package.Rd
+++ b/man/workr-package.Rd
@@ -21,6 +21,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Jeremy Wildfire \email{jwildfire@gilead.com}
   \item Zelos Zhu \email{zelos.zhu@atorus.com}
 }
 

--- a/tests/testthat/helper-logging.R
+++ b/tests/testthat/helper-logging.R
@@ -1,0 +1,30 @@
+# Test helper: silence expected log levels via the `appender()` seam.
+#
+# `LogMessage()` routes all output through `appender()`, so mocking that one
+# binding suppresses log chatter without `suppressMessages()` wrappers -- which
+# would also swallow genuine `message()` conditions a test means to assert on.
+
+#' Silence log output for the given levels within the calling test
+#'
+#' Levels not listed still reach the console, so an unexpected `warn` or `fatal`
+#' record stays visible rather than being hidden by a blanket suppression.
+#'
+#' @param levels Character vector of log levels to discard.
+#' @param .env Environment whose exit triggers the unmock; defaults to the caller.
+#'
+#' @keywords internal
+#' @noRd
+local_quiet_log <- function(levels = "info", .env = parent.frame()) {
+  levels <- tolower(levels)
+
+  testthat::local_mocked_bindings(
+    appender = function(level, msg) {
+      if (tolower(level) %in% levels) {
+        return(invisible(NULL))
+      }
+      message("[", toupper(level), "] ", msg)
+    },
+    .package = "workr",
+    .env = .env
+  )
+}

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -161,6 +161,32 @@ test_that(".ResolveSpecPath resolves relative to the workflow file (#91)", {
   )
 })
 
+test_that(".ResolveSpecPath resolves multi-segment relative paths (#91)", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "workflows"))
+  dir.create(file.path(dir, "specs"))
+  nested_spec <- file.path(dir, "specs", "DM_spec.yaml")
+  parent_spec <- file.path(dir, "DM_spec.yaml")
+  writeLines("steps: []", nested_spec)
+  writeLines("steps: []", parent_spec)
+  str_path <- file.path(dir, "workflows", "DM.yaml")
+
+  expect_identical(
+    normalizePath(
+      .ResolveSpecPath("../specs/DM_spec.yaml", "DM", str_path),
+      winslash = "/"
+    ),
+    normalizePath(nested_spec, winslash = "/")
+  )
+  expect_identical(
+    normalizePath(
+      .ResolveSpecPath("../DM_spec.yaml", "DM", str_path),
+      winslash = "/"
+    ),
+    normalizePath(parent_spec, winslash = "/")
+  )
+})
+
 test_that(".ResolveSpecPath errors on a missing spec file (#91)", {
   expect_error(
     .ResolveSpecPath("nope.yaml", "DM", NULL),

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -133,6 +133,13 @@ test_that(".SpecDialect errors rather than degrading to legacy (#91)", {
   expect_error(.SpecDialect(c("a", "b"), "d"), "Unrecognized spec format")
 })
 
+test_that(".SpecDialect rejects a pointblank spec missing `steps` (#91)", {
+  expect_error(
+    .SpecDialect(list(tbl_name = "AE", thresholds = list(error = 1)), "AE"),
+    "no `steps`"
+  )
+})
+
 # --- .ResolveSpecPath -----------------------------------------------------
 
 test_that(".ResolveSpecPath resolves relative to the workflow file (#91)", {
@@ -279,7 +286,11 @@ test_that("`_all` is counted as a validation step", {
   expect_identical(.CheckSpecLegacy(data.frame(a = 1), spec, "d")$n_steps, 1L)
 
   expect_identical(
-    .CheckSpecLegacy(data.frame(a = 1), list(a = list(type = "numeric")), "d")$n_steps,
+    .CheckSpecLegacy(
+      data.frame(a = 1),
+      list(a = list(type = "numeric")),
+      "d"
+    )$n_steps,
     0L
   )
 })

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -135,7 +135,7 @@ test_that(".SpecDialect errors rather than degrading to legacy (#91)", {
 
 test_that(".SpecDialect rejects a pointblank spec missing `steps` (#91)", {
   expect_error(
-    .SpecDialect(list(tbl_name = "AE", thresholds = list(error = 1)), "AE"),
+    .SpecDialect(list(tbl = "AE", thresholds = list(error = 1)), "AE"),
     "no `steps`"
   )
 })
@@ -173,11 +173,11 @@ test_that(".ResolveSpecPath errors on a missing spec file (#91)", {
 test_that(".LoadSpec reads files and passes inline specs through (#91)", {
   dir <- withr::local_tempdir()
   spec_path <- file.path(dir, "DM_spec.yaml")
-  writeLines(c("tbl_name: dm", "steps:", "  - rows_distinct"), spec_path)
+  writeLines(c("tbl: dm", "steps:", "  - rows_distinct"), spec_path)
 
   expect_identical(
     .LoadSpec(spec_path, "pointblank_file", "DM"),
-    list(tbl_name = "dm", steps = "rows_distinct")
+    list(tbl = "dm", steps = "rows_distinct")
   )
 
   inline <- list(steps = list("rows_distinct"))

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -1,0 +1,314 @@
+# Tests for the internal helpers in R/internal.R.
+
+# --- GetStrFunctionIfNamespaced ------------------------------------------
+
+test_that("GetStrFunctionIfNamespaced rejects non-string input", {
+  expect_error(
+    GetStrFunctionIfNamespaced(1),
+    "must be a single character string"
+  )
+  expect_error(
+    GetStrFunctionIfNamespaced(c("a", "b")),
+    "must be a single character string"
+  )
+})
+
+test_that("GetStrFunctionIfNamespaced resolves namespaced names", {
+  expect_identical(GetStrFunctionIfNamespaced("utils::head"), utils::head)
+})
+
+test_that("GetStrFunctionIfNamespaced rejects malformed namespaced names", {
+  # "a::b::c" splits into three parts, "a::" into one.
+  expect_error(
+    GetStrFunctionIfNamespaced("utils::head::extra"),
+    "Invalid namespaced function string"
+  )
+  expect_error(
+    GetStrFunctionIfNamespaced("utils::"),
+    "Invalid namespaced function string"
+  )
+})
+
+test_that("GetStrFunctionIfNamespaced prefers a global binding", {
+  fn <- function() "from_global"
+  assign("workr_test_global_fn", fn, envir = .GlobalEnv)
+  withr::defer(rm("workr_test_global_fn", envir = .GlobalEnv))
+
+  expect_identical(GetStrFunctionIfNamespaced("workr_test_global_fn"), fn)
+})
+
+test_that("GetStrFunctionIfNamespaced finds a caller-local binding", {
+  local_fn <- function() "from_caller"
+  expect_identical(GetStrFunctionIfNamespaced("local_fn"), local_fn)
+})
+
+test_that("GetStrFunctionIfNamespaced falls back to the workr namespace", {
+  # Call from an environment isolated from both the global env and the workr
+  # namespace, so the earlier `exists()` branches cannot match.
+  isolated <- new.env(parent = baseenv())
+  isolated$GetStrFunctionIfNamespaced <- GetStrFunctionIfNamespaced
+
+  expect_identical(
+    evalq(GetStrFunctionIfNamespaced("stop_if"), isolated),
+    stop_if
+  )
+
+  # The namespace search inherits through base and the attached search path,
+  # so attached-package functions resolve unqualified as well.
+  expect_identical(
+    evalq(GetStrFunctionIfNamespaced("read.csv"), isolated),
+    utils::read.csv
+  )
+})
+
+test_that("GetStrFunctionIfNamespaced errors when the name is unresolvable", {
+  expect_error(
+    GetStrFunctionIfNamespaced("workr_no_such_function_anywhere"),
+    "not found"
+  )
+})
+
+# --- CheckSpec early exits ------------------------------------------------
+
+test_that("CheckSpec is a no-op when either side is absent", {
+  expect_identical(CheckSpec(NULL, list(d = list())), list())
+  expect_identical(CheckSpec(list(d = data.frame(a = 1)), NULL), list())
+})
+
+test_that("CheckSpec is a no-op for an empty or non-list spec", {
+  expect_identical(CheckSpec(list(d = data.frame(a = 1)), list()), list())
+  expect_identical(CheckSpec(list(d = data.frame(a = 1)), "not-a-list"), list())
+})
+
+# --- stop_if --------------------------------------------------------------
+
+test_that("stop_if only stops on TRUE and interpolates from the caller", {
+  expect_true(stop_if(FALSE, "never seen"))
+  expect_true(stop_if(NA, "never seen"))
+
+  f <- function() {
+    what <- "widget"
+    stop_if(TRUE, "Bad {what}.")
+  }
+  expect_error(f(), "Bad widget.")
+})
+
+# --- %||% -----------------------------------------------------------------
+
+test_that("%||% returns the left side unless it is NULL", {
+  expect_identical(1 %||% 2, 1)
+  expect_identical(NULL %||% 2, 2)
+})
+
+# --- LogMessage / appender ------------------------------------------------
+
+test_that("LogMessage formats and routes through appender()", {
+  expect_message(LogMessage("info", "hello"), "\\[INFO\\] hello")
+
+  what <- "world"
+  expect_message(LogMessage("warn", "hello {what}"), "\\[WARN\\] hello world")
+})
+
+test_that("LogMessage accepts cli_detail", {
+  expect_message(
+    LogMessage("info", "hello", cli_detail = "extra"),
+    "\\[INFO\\] hello"
+  )
+})
+
+# --- .SpecDialect ---------------------------------------------------------
+
+test_that(".SpecDialect classifies each supported shape (#91)", {
+  expect_identical(.SpecDialect("spec.yaml", "d"), "pointblank_file")
+  expect_identical(.SpecDialect(list(steps = list()), "d"), "pointblank_inline")
+  expect_identical(.SpecDialect(list(required_cols = "a"), "d"), "legacy")
+  expect_identical(.SpecDialect(list(), "d"), "legacy")
+})
+
+test_that(".SpecDialect errors rather than degrading to legacy (#91)", {
+  # An unnamed, non-empty list matches no dialect: erroring here prevents a
+  # malformed pointblank spec from silently becoming "no validation".
+  expect_error(.SpecDialect(list(1, 2), "d"), "Unrecognized spec format")
+  expect_error(.SpecDialect(1L, "d"), "Unrecognized spec format")
+  expect_error(.SpecDialect(c("a", "b"), "d"), "Unrecognized spec format")
+})
+
+# --- .ResolveSpecPath -----------------------------------------------------
+
+test_that(".ResolveSpecPath resolves relative to the workflow file (#91)", {
+  dir <- withr::local_tempdir()
+  spec_path <- file.path(dir, "DM_spec.yaml")
+  writeLines("steps: []", spec_path)
+
+  expect_identical(
+    normalizePath(
+      .ResolveSpecPath("DM_spec.yaml", "DM", file.path(dir, "DM.yaml")),
+      winslash = "/"
+    ),
+    normalizePath(spec_path, winslash = "/")
+  )
+  # An existing path is used as-is, ignoring strPath.
+  expect_identical(
+    .ResolveSpecPath(spec_path, "DM", "elsewhere/DM.yaml"),
+    spec_path
+  )
+})
+
+test_that(".ResolveSpecPath errors on a missing spec file (#91)", {
+  expect_error(
+    .ResolveSpecPath("nope.yaml", "DM", NULL),
+    "Spec file for domain 'DM' not found: nope.yaml"
+  )
+})
+
+# --- .LoadSpec ------------------------------------------------------------
+
+test_that(".LoadSpec reads files and passes inline specs through (#91)", {
+  dir <- withr::local_tempdir()
+  spec_path <- file.path(dir, "DM_spec.yaml")
+  writeLines(c("tbl_name: dm", "steps:", "  - rows_distinct"), spec_path)
+
+  expect_identical(
+    .LoadSpec(spec_path, "pointblank_file", "DM"),
+    list(tbl_name = "dm", steps = "rows_distinct")
+  )
+
+  inline <- list(steps = list("rows_distinct"))
+  expect_identical(.LoadSpec(inline, "pointblank_inline", "DM"), inline)
+})
+
+# --- .EnforceSpecResult ---------------------------------------------------
+
+make_result <- function(level) {
+  list(
+    domain = "DM",
+    dialect = "pointblank",
+    level = level,
+    passed = level == "pass",
+    n_steps = 3L,
+    n_failed_steps = 1L,
+    failed_steps = "col_vals_not_null"
+  )
+}
+
+test_that(".EnforceSpecResult aborts on error and critical (#91)", {
+  expect_error(
+    .EnforceSpecResult(make_result("error")),
+    "Spec validation failed for 'DM' at level 'error': 1 of 3 step\\(s\\) failed"
+  )
+  expect_error(
+    .EnforceSpecResult(make_result("critical")),
+    "at level 'critical'"
+  )
+})
+
+test_that(".EnforceSpecResult logs but continues on warning (#91)", {
+  expect_message(
+    .EnforceSpecResult(make_result("warning")),
+    "Spec validation warning for 'DM': 1 of 3 step\\(s\\) failed."
+  )
+})
+
+test_that(".EnforceSpecResult is silent on pass and returns the result (#91)", {
+  result <- make_result("pass")
+  expect_silent(out <- .EnforceSpecResult(result))
+  expect_identical(out, result)
+})
+
+# --- .CheckSpecLegacy -----------------------------------------------------
+
+test_that(".CheckSpecLegacy accepts each historical required-columns key (#91)", {
+  data <- data.frame(a = 1, b = 2)
+
+  for (key in c("required_cols", "required", "columns")) {
+    spec <- stats::setNames(list(c("a", "b")), key)
+    expect_identical(.CheckSpecLegacy(data, spec, "d")$n_steps, 2L)
+  }
+})
+
+test_that(".CheckSpecLegacy tolerates a spec with no required columns (#91)", {
+  result <- .CheckSpecLegacy(
+    data.frame(a = 1),
+    list(a = list(type = "numeric")),
+    "d"
+  )
+
+  expect_true(result$passed)
+  expect_identical(result$n_steps, 0L)
+  expect_identical(result$dialect, "legacy")
+})
+
+# --- `_all` wildcard ------------------------------------------------------
+
+test_that(".SpecWildcardRequired detects only an explicit required wildcard", {
+  expect_true(.SpecWildcardRequired(list(`_all` = list(required = TRUE))))
+
+  expect_false(.SpecWildcardRequired(list(`_all` = list(required = FALSE))))
+  expect_false(.SpecWildcardRequired(list(`_all` = list())))
+  expect_false(.SpecWildcardRequired(list(required_cols = "a")))
+  expect_false(.SpecWildcardRequired("a-path.yaml"))
+})
+
+test_that("`_all` passes for any non-empty table regardless of shape", {
+  # The wildcard names no columns, so it deliberately claims nothing about
+  # them -- including nullability. Two unrelated tables both satisfy it.
+  spec <- list(`_all` = list(required = TRUE))
+
+  expect_true(.CheckSpecLegacy(data.frame(a = 1, b = "x"), spec, "d")$passed)
+  expect_true(
+    .CheckSpecLegacy(data.frame(z = c(NA, 2)), spec, "d")$passed
+  )
+})
+
+test_that("`_all` rejects an empty table", {
+  spec <- list(`_all` = list(required = TRUE))
+
+  expect_error(
+    .CheckSpecLegacy(data.frame(a = integer(0)), spec, "d"),
+    "Required input 'd' is empty."
+  )
+  expect_error(
+    .CheckSpecLegacy(data.frame(), spec, "d"),
+    "Required input 'd' is empty."
+  )
+})
+
+test_that("`_all` is counted as a validation step", {
+  # n_steps distinguishes a wildcard that ran from a spec that checked nothing.
+  spec <- list(`_all` = list(required = TRUE))
+  expect_identical(.CheckSpecLegacy(data.frame(a = 1), spec, "d")$n_steps, 1L)
+
+  expect_identical(
+    .CheckSpecLegacy(data.frame(a = 1), list(a = list(type = "numeric")), "d")$n_steps,
+    0L
+  )
+})
+
+test_that("`_all` combines with an explicit required column list", {
+  spec <- list(`_all` = list(required = TRUE), required_cols = c("a", "b"))
+
+  expect_identical(
+    .CheckSpecLegacy(data.frame(a = 1, b = 2), spec, "d")$n_steps,
+    3L
+  )
+  expect_error(
+    .CheckSpecLegacy(data.frame(a = 1), spec, "d"),
+    "Missing required columns"
+  )
+})
+
+test_that("`_all` reaches CheckSpec through the legacy dispatch path", {
+  expect_error(
+    CheckSpec(
+      list(d = data.frame(a = integer(0))),
+      list(d = list(`_all` = list(required = TRUE)))
+    ),
+    "Required input 'd' is empty."
+  )
+  expect_silent(
+    CheckSpec(
+      list(d = data.frame(a = 1)),
+      list(d = list(`_all` = list(required = TRUE)))
+    )
+  )
+})

--- a/tests/testthat/test-load-example.R
+++ b/tests/testthat/test-load-example.R
@@ -1,3 +1,5 @@
+local_quiet_log("info")
+
 test_that("loadExample returns input data when initData.R is missing (#9, #26)", {
   wf <- list(path = tempfile(fileext = ".yaml"))
   lData <- list(x = 1)

--- a/tests/testthat/test-run-project.R
+++ b/tests/testthat/test-run-project.R
@@ -1,3 +1,8 @@
+# `RunProject()` emits ~25 [INFO] records per call. Silence that level for the
+# whole file via the `appender()` seam; `warn`/`error`/`fatal` still surface, so
+# tests asserting on them (e.g. "has no workflows") keep working.
+local_quiet_log("info")
+
 test_that("RunProject runs all phases in sorted order (#26)", {
   sum_step <- function(lData, y) lData$value + y
   assign("sum_step", sum_step, envir = globalenv())
@@ -150,11 +155,15 @@ test_that("RunProject warns on empty phase folder and proceeds (#63)", {
     file.path(proj, "1_populated", "y_step.yaml")
   )
 
-  # Assign inside expect_message(): it returns the matched condition, not the
-  # value of the expression, so capture RunProject()'s result via assignment.
+  # Two [WARN] records are emitted here: MakeWorkflowList() reports the empty
+  # folder first, then RunProject() reports skipping the phase. Assert both --
+  # expect_message() consumes only one matching condition each.
   result <- NULL
   expect_message(
-    result <- RunProject(strPath = proj, lData = list(value = 5)),
+    expect_message(
+      result <- RunProject(strPath = proj, lData = list(value = 5)),
+      "No workflows found"
+    ),
     "no workflows"
   )
 
@@ -420,7 +429,9 @@ test_that("RunProject supports a four-phase configured project scenario (#67)", 
     )
   }
   coerce_group_id <- function(phase_result) {
-    phase_result$phase_metrics$GroupID <- as.character(phase_result$phase_metrics$GroupID)
+    phase_result$phase_metrics$GroupID <- as.character(
+      phase_result$phase_metrics$GroupID
+    )
     phase_result
   }
   assign("make_mapped", make_mapped, envir = globalenv())
@@ -569,10 +580,17 @@ test_that("RunProject continue-on-error returns project failure summary (#11)", 
     params = list(lData = "lData")
   )
 
-  result <- RunProject(
-    project_path,
-    lData = list(seed = "initial"),
-    bContinueOnError = TRUE
+  # Assign inside expect_message(): it returns the matched condition, not the
+  # value. The [ERROR] record is the observable signal that continue-on-error
+  # caught the failure and kept going.
+  result <- NULL
+  expect_message(
+    result <- RunProject(
+      project_path,
+      lData = list(seed = "initial"),
+      bContinueOnError = TRUE
+    ),
+    "Workflow 'phase_bad' failed: phase boom"
   )
 
   expect_s3_class(result, "workr_project_summary")
@@ -622,12 +640,10 @@ test_that("RunProject retains fail-fast behavior by default (#67)", {
     params = list(lData = "lData")
   )
 
-  suppressMessages({
-    expect_error(
-      RunProject(project_path, lData = list(seed = "initial")),
-      "phase boom"
-    )
-  })
+  expect_error(
+    RunProject(project_path, lData = list(seed = "initial")),
+    "phase boom"
+  )
   expect_false(capture_ran)
 })
 
@@ -686,7 +702,11 @@ test_that("RunProject supports phase-scoped and project-scoped hooks (#17)", {
     )
   )
 
-  result <- RunProject(project_path, lData = list(seed = "initial"), lConfig = lConfig)
+  result <- RunProject(
+    project_path,
+    lData = list(seed = "initial"),
+    lConfig = lConfig
+  )
 
   expect_equal(project_load_count, 1)
   expect_equal(project_save_count, 1)

--- a/tests/testthat/test-snapshot-gh-mocks.R
+++ b/tests/testthat/test-snapshot-gh-mocks.R
@@ -225,13 +225,25 @@ test_that("pkgManifest writes manifest outputs with mocked GitHub resolution (#4
     }
   )
 
-  out <- pkgManifest(
-    path = tmp,
-    packageList = c(
-      "Gilead-BioStats/gsm.core@v1.2.3",
-      "Gilead-BioStats/gsm.mapping"
+  # expect_message() returns the matched condition, not the value, so assign
+  # inside it and nest to consume each of the three [INFO]-style records.
+  out <- NULL
+  expect_message(
+    expect_message(
+      expect_message(
+        out <- pkgManifest(
+          path = tmp,
+          packageList = c(
+            "Gilead-BioStats/gsm.core@v1.2.3",
+            "Gilead-BioStats/gsm.mapping"
+          ),
+          branch = "dev"
+        ),
+        "Wrote manifest\\.csv"
+      ),
+      "Wrote rproject\\.toml"
     ),
-    branch = "dev"
+    "Pulled workflows"
   )
 
   expect_true(file.exists(file.path(tmp, "manifest.csv")))
@@ -387,6 +399,8 @@ test_that("pull_workflows dispatches file and directory entries (#43)", {
     repo = "gsm.core",
     sha = "abc123"
   ))
+  # No message assertion here: both pull_workflow_dir() and pull_workflow_file()
+  # are mocked out, so nothing reaches the real "Pulled ..." emitter.
   pull_workflows(resolved, tmp)
 
   expect_length(dir_calls, 1)
@@ -438,7 +452,9 @@ test_that("pull_workflow_file writes decoded file when content is available (#43
     sha = "abc123",
     api_path = "inst/workflow/root.yaml",
     local_path = tmp
-  )
+  ) |>
+    # The filename is a random tempfile, so match only the stable suffix.
+    expect_message("from Gilead-BioStats/gsm\\.core")
 
   expect_true(file.exists(tmp))
   expect_identical(readLines(tmp)[1], "name: workflow")
@@ -488,7 +504,8 @@ test_that("pull_workflows does not register missing files as collisions (#46)", 
     list(org = "Gilead-BioStats", repo = "pkg.two", sha = "sha2")
   )
 
-  workr:::pull_workflows(resolved, tmp)
+  workr:::pull_workflows(resolved, tmp) |>
+    expect_message("Pulled root\\.yaml from Gilead-BioStats/pkg\\.two")
 
   expect_identical(
     readLines(file.path(tmp, "workflows", "root.yaml"))[1],
@@ -543,7 +560,9 @@ test_that("pull_workflows warns on destination collisions by default (#46)", {
   expect_warning(
     workr:::pull_workflows(resolved, tmp),
     "Workflow destination collision.*pkg\\.one.*pkg\\.two"
-  )
+  ) |>
+    expect_message("Pulled root\\.yaml from Gilead-BioStats/pkg\\.one") |>
+    expect_message("Pulled root\\.yaml from Gilead-BioStats/pkg\\.two")
   expect_identical(
     readLines(file.path(tmp, "workflows", "root.yaml"))[1],
     "name: pkg.two"
@@ -604,7 +623,9 @@ test_that("pull_workflows warns on nested destination collisions in directories 
   expect_warning(
     workr:::pull_workflows(resolved, tmp),
     "Workflow destination collision.*pkg\\.one.*pkg\\.two"
-  )
+  ) |>
+    expect_message("Pulled nested\\.yaml from Gilead-BioStats/pkg\\.one") |>
+    expect_message("Pulled nested\\.yaml from Gilead-BioStats/pkg\\.two")
   expect_identical(
     readLines(file.path(tmp, "workflows", "shared", "nested.yaml"))[1],
     "name: pkg.two.nested"
@@ -668,7 +689,8 @@ test_that("pull_workflows warns and skips file-vs-directory structural collision
   expect_warning(
     workr:::pull_workflows(resolved, tmp),
     "Cannot create workflow directory"
-  )
+  ) |>
+    expect_message("Pulled foo from Gilead-BioStats/pkg\\.one")
   expect_true(file.exists(file.path(tmp, "workflows", "foo")))
   expect_false(file.exists(file.path(tmp, "workflows", "foo", "bar.yaml")))
   expect_equal(

--- a/tests/testthat/test-spec-pointblank.R
+++ b/tests/testthat/test-spec-pointblank.R
@@ -248,17 +248,63 @@ test_that("spec file paths resolve relative to the workflow file (#91)", {
   expect_true(res$dm_raw$passed)
 })
 
-test_that("`tbl_name` is not partial-matched as `tbl` (#91)", {
+test_that("`tbl` names the table to validate, `tbl_name` labels the agent (#91)", {
   skip_if_not_installed("pointblank")
-  # `spec$tbl` partial-matches `tbl_name`, which would wrongly trigger the
-  # "ignoring tbl" path for every spec that names its table.
-  expect_no_message(
+  agent <- .PbInterrogate(
+    make_df(),
+    list(tbl = "Raw_AE", tbl_name = "Raw AE", steps = list("rows_distinct")),
+    "d"
+  )
+  expect_equal(agent$tbl_name, "Raw AE")
+
+  # `tbl:` must not stand in for an absent `tbl_name:`; the domain does.
+  expect_equal(
+    .PbInterrogate(
+      make_df(),
+      list(tbl = "Raw_AE", steps = list("rows_distinct")),
+      "d"
+    )$tbl_name,
+    "d"
+  )
+})
+
+test_that("`tbl` written in R formula form resolves to the bare name (#91)", {
+  expect_equal(.SpecTbl(list(tbl = "~ Raw_AE"), "d"), "Raw_AE")
+  expect_equal(.SpecTbl(list(tbl = "Raw_AE"), "d"), "Raw_AE")
+  expect_equal(.SpecTbl(list(steps = list()), "d"), "d")
+})
+
+test_that("`tbl_name` is accepted but does not stand in for `tbl` (#91)", {
+  skip_if_not_installed("pointblank")
+  # `tbl_name` is part of the pointblank YAML spec and harmless, but `spec$tbl`
+  # would partial-match it, so it must not be read as the table to validate.
+  expect_equal(.SpecTbl(list(tbl_name = "other"), "d"), "d")
+  expect_no_warning(
     .PbInterrogate(
       make_df(),
       list(tbl_name = "d", steps = list("rows_distinct")),
       "d"
     )
   )
+})
+test_that("a spec naming a table absent from lData errors clearly (#91)", {
+  skip_if_not_installed("pointblank")
+  expect_error(
+    CheckSpec(
+      list(d = make_df()),
+      list(d = list(tbl = "other", steps = list("rows_distinct")))
+    ),
+    "names table 'other'"
+  )
+})
+
+test_that("`tbl` may point at a different element of lData (#91)", {
+  skip_if_not_installed("pointblank")
+  res <- suppressMessages(CheckSpec(
+    list(d = make_df(), source = make_df()),
+    list(d = list(tbl = "source", steps = list("rows_distinct")))
+  ))
+  expect_true(res$d$passed)
 })
 
 test_that("a missing spec file errors clearly (#91)", {
@@ -336,11 +382,19 @@ test_that(".EnforceSpecResult applies the failure contract (#91)", {
 test_that(".CheckSpecDomain dispatches on dialect (#91)", {
   skip_if_not_installed("pointblank")
 
-  legacy <- .CheckSpecDomain(make_df(), list(required_cols = "STUDYID"), "d")
+  legacy <- .CheckSpecDomain(
+    list(d = make_df()),
+    list(required_cols = "STUDYID"),
+    "d"
+  )
   expect_equal(legacy$dialect, "legacy")
 
   pb <- suppressMessages(
-    .CheckSpecDomain(make_df(), list(steps = list("rows_distinct")), "d")
+    .CheckSpecDomain(
+      list(d = make_df()),
+      list(steps = list("rows_distinct")),
+      "d"
+    )
   )
   expect_equal(pb$dialect, "pointblank")
 })
@@ -419,21 +473,6 @@ test_that(".PbTranslateStep warns on methods outside the portable subset (#91)",
     "outside the cross-language portable subset"
   )
   expect_identical(step$method, "col_vals_expr")
-})
-
-test_that(".PbInterrogate logs that a spec-supplied `tbl` is ignored (#91)", {
-  skip_if_not_installed("pointblank")
-
-  # `tbl:` is an R formula in R and a lambda in Python -- the one field that
-  # provably cannot round-trip -- so workflow-supplied data always wins.
-  expect_message(
-    .PbInterrogate(
-      make_df(),
-      list(tbl = "~ some_other_data", steps = list("rows_distinct")),
-      "d"
-    ),
-    "Ignoring `tbl` in spec"
-  )
 })
 
 test_that(".PbInterrogate errors on an unknown validation method (#91)", {

--- a/tests/testthat/test-spec-pointblank.R
+++ b/tests/testthat/test-spec-pointblank.R
@@ -403,7 +403,13 @@ test_that(".PbTranslateStep rejects malformed steps (#91)", {
   msg <- "Each entry of `steps` must be a validation method name or a single-key mapping"
   expect_error(.PbTranslateStep(list("col_exists")), msg)
   expect_error(.PbTranslateStep(42), msg)
-  expect_error(.PbTranslateStep(c("a", "b")), msg)
+})
+
+test_that(".PbTranslateStep rejects multi-key steps rather than dropping them (#91)", {
+  expect_error(
+    .PbTranslateStep(list(col_exists = "A", rows_distinct = NULL)),
+    "single-key mapping; got 2 keys"
+  )
 })
 
 test_that(".PbTranslateStep warns on methods outside the portable subset (#91)", {

--- a/tests/testthat/test-spec-pointblank.R
+++ b/tests/testthat/test-spec-pointblank.R
@@ -1,0 +1,678 @@
+# Tests for pointblank-style spec support (#91)
+
+make_df <- function() {
+  data.frame(
+    STUDYID = c("S1", "S1", "S1"),
+    USUBJID = c("A", "B", "C"),
+    stringsAsFactors = FALSE
+  )
+}
+
+# --- Backward compatibility: legacy dialect ------------------------------
+
+test_that("legacy specs still validate on column existence (#91)", {
+  expect_error(
+    CheckSpec(
+      list(d = data.frame(a = 1)),
+      list(d = list(required_cols = c("a", "b")))
+    ),
+    "Missing required columns"
+  )
+
+  expect_silent(
+    CheckSpec(
+      list(d = data.frame(a = 1, b = 2)),
+      list(d = list(required_cols = c("a", "b")))
+    )
+  )
+})
+
+test_that("legacy specs deliberately do NOT enforce declared types (#91)", {
+  # STUDYID is declared character but supplied as numeric. This must still pass:
+  # enforcing types would newly break workflows that pass today.
+  expect_silent(
+    CheckSpec(
+      list(d = data.frame(STUDYID = 1L)),
+      list(d = list(STUDYID = list(type = "character")))
+    )
+  )
+})
+
+test_that("CheckSpec still errors on a missing domain (#91)", {
+  expect_error(
+    CheckSpec(list(), list(d = list(required_cols = "a"))),
+    "Spec-declared input 'd' not found in lData"
+  )
+})
+
+test_that("CheckSpec returns per-domain results (#91)", {
+  res <- CheckSpec(
+    list(d = data.frame(a = 1)),
+    list(d = list(required_cols = "a"))
+  )
+  expect_named(res, "d")
+  expect_equal(res$d$dialect, "legacy")
+  expect_true(res$d$passed)
+})
+
+# --- Dialect detection ---------------------------------------------------
+
+test_that("spec dialects are detected and bad shapes error (#91)", {
+  expect_equal(.SpecDialect("f_spec.yaml", "d"), "pointblank_file")
+  expect_equal(.SpecDialect(list(steps = list()), "d"), "pointblank_inline")
+  expect_equal(.SpecDialect(list(a = list(type = "character")), "d"), "legacy")
+
+  # An unnamed list is not a valid legacy spec and must not silently pass.
+  expect_error(.SpecDialect(list(1, 2), "d"), "Unrecognized spec format")
+})
+
+# --- Translation layer ---------------------------------------------------
+
+test_that("Python-form method and argument names are translated (#91)", {
+  expect_equal(
+    .PbTranslateStep(list(col_vals_le = list(columns = "a", value = 5)))$method,
+    "col_vals_lte"
+  )
+  expect_equal(
+    .PbTranslateStep(list(col_vals_ge = list(columns = "a", value = 5)))$method,
+    "col_vals_gte"
+  )
+
+  # `pattern` errors loudly in R pointblank; it must become `regex`.
+  step <- .PbTranslateStep(list(
+    col_vals_regex = list(columns = "b", pattern = "x")
+  ))
+  expect_true("regex" %in% names(step$args))
+  expect_false("pattern" %in% names(step$args))
+})
+
+test_that("bare-string steps are supported (#91)", {
+  # R pointblank's own YAML reader fails on these with "argument is of length zero".
+  step <- .PbTranslateStep("rows_distinct")
+  expect_equal(step$method, "rows_distinct")
+  expect_equal(step$args, list())
+})
+
+test_that("Python severity names map to action_levels arguments (#91)", {
+  args <- .PbThresholdArgs(list(warning = 0.1, error = 0.2, critical = 0.3))
+  expect_equal(args, list(warn_at = 0.1, stop_at = 0.2, notify_at = 0.3))
+
+  # The *_fraction serialization spellings are also accepted.
+  expect_equal(.PbThresholdArgs(list(warn_fraction = 0.5)), list(warn_at = 0.5))
+})
+
+test_that("step-level thresholds merge over global rather than replacing (#91)", {
+  # Verified on pointblank 0.12.4: passing step-level actions REPLACES the global
+  # action_levels, leaving unspecified levels NA. Merging keeps the global error.
+  step <- .PbTranslateStep(
+    list(
+      col_vals_gt = list(
+        columns = "a",
+        value = 0,
+        thresholds = list(warning = 0.01)
+      )
+    ),
+    global_thresholds = list(warn_at = 0.1, stop_at = 0.5)
+  )
+  expect_equal(step$args$actions$warn_fraction, 0.01)
+  expect_equal(step$args$actions$stop_fraction, 0.5)
+  expect_null(step$args$thresholds)
+})
+
+# --- The safety-critical regression --------------------------------------
+
+test_that("unrecognized top-level keys warn instead of vanishing (#91)", {
+  skip_if_not_installed("pointblank")
+  # R pointblank silently discards unknown top-level keys. A spec whose
+  # thresholds were misspelled would otherwise report success with no severity
+  # levels at all -- the worst failure mode for a validation pipeline.
+  expect_warning(
+    .PbInterrogate(
+      make_df(),
+      list(totally_bogus_key = 3, steps = list("rows_distinct")),
+      "d"
+    ),
+    "unrecognized top-level spec key"
+  )
+})
+
+test_that("Python-only governance keys are accepted without warning (#91)", {
+  skip_if_not_installed("pointblank")
+  expect_no_warning(
+    .PbInterrogate(
+      make_df(),
+      list(
+        df_library = "polars",
+        owner = "Data Eng",
+        steps = list("rows_distinct")
+      ),
+      "d"
+    )
+  )
+})
+
+test_that("undocumented vector column refs still expand to multiple steps (#91)", {
+  skip_if_not_installed("pointblank")
+  # `columns: [a, b]` expanding to two steps is undocumented behavior worth a
+  # canary test.
+  agent <- .PbInterrogate(
+    make_df(),
+    list(
+      steps = list(list(col_exists = list(columns = c("STUDYID", "USUBJID"))))
+    ),
+    "d"
+  )
+  expect_equal(nrow(agent$validation_set), 2)
+})
+
+# --- Failure contract ----------------------------------------------------
+
+test_that("error-level breaches abort the workflow (#91)", {
+  skip_if_not_installed("pointblank")
+  spec <- list(
+    thresholds = list(error = 0.01),
+    steps = list(list(col_vals_not_null = list(columns = "STUDYID")))
+  )
+  df <- make_df()
+  df$STUDYID[1] <- NA
+
+  expect_error(
+    suppressMessages(CheckSpec(list(d = df), list(d = spec))),
+    "Spec validation failed for 'd' at level 'error'"
+  )
+})
+
+test_that("warning-level breaches log and continue (#91)", {
+  skip_if_not_installed("pointblank")
+  spec <- list(
+    thresholds = list(warning = 0.01),
+    steps = list(list(col_vals_not_null = list(columns = "STUDYID")))
+  )
+  df <- make_df()
+  df$STUDYID[1] <- NA
+
+  res <- suppressMessages(CheckSpec(list(d = df), list(d = spec)))
+  expect_equal(res$d$level, "warning")
+  expect_false(res$d$passed)
+})
+
+test_that("a passing pointblank spec returns a pass result (#91)", {
+  skip_if_not_installed("pointblank")
+  res <- suppressMessages(CheckSpec(
+    list(d = make_df()),
+    list(
+      d = list(
+        steps = list(
+          list(col_exists = list(columns = c("STUDYID", "USUBJID"))),
+          "rows_distinct"
+        )
+      )
+    )
+  ))
+  expect_true(res$d$passed)
+  expect_equal(res$d$level, "pass")
+  expect_equal(res$d$dialect, "pointblank")
+})
+
+test_that("an unset threshold level never aborts (#91)", {
+  skip_if_not_installed("pointblank")
+  # `notify` is NA when unset; NA must not be treated as a breach.
+  df <- make_df()
+  df$STUDYID[1] <- NA
+  res <- suppressMessages(CheckSpec(
+    list(d = df),
+    list(
+      d = list(
+        steps = list(list(col_vals_not_null = list(columns = "STUDYID")))
+      )
+    )
+  ))
+  expect_equal(res$d$level, "pass")
+})
+
+# --- Spec files ----------------------------------------------------------
+
+test_that("spec file paths resolve relative to the workflow file (#91)", {
+  skip_if_not_installed("pointblank")
+  workflow_path <- system.file(
+    "example_workflows/04_Example_RAW_TO_SDTM/DM.yaml",
+    package = "workr"
+  )
+  skip_if(workflow_path == "")
+
+  res <- suppressMessages(CheckSpec(
+    list(dm_raw = make_df()),
+    list(dm_raw = "DM_dm_raw_spec.yaml"),
+    strPath = workflow_path
+  ))
+  expect_true(res$dm_raw$passed)
+})
+
+test_that("`tbl_name` is not partial-matched as `tbl` (#91)", {
+  skip_if_not_installed("pointblank")
+  # `spec$tbl` partial-matches `tbl_name`, which would wrongly trigger the
+  # "ignoring tbl" path for every spec that names its table.
+  expect_no_message(
+    .PbInterrogate(
+      make_df(),
+      list(tbl_name = "d", steps = list("rows_distinct")),
+      "d"
+    )
+  )
+})
+
+test_that("a missing spec file errors clearly (#91)", {
+  expect_error(
+    CheckSpec(list(d = make_df()), list(d = "does_not_exist_spec.yaml")),
+    "Spec file for domain 'd' not found"
+  )
+})
+
+# --- Extracted helpers ---------------------------------------------------
+
+test_that(".ResolveSpecPath resolves relative to the workflow file (#91)", {
+  workflow_path <- system.file(
+    "example_workflows/04_Example_RAW_TO_SDTM/DM.yaml",
+    package = "workr"
+  )
+  skip_if(workflow_path == "")
+
+  path <- .ResolveSpecPath("DM_dm_raw_spec.yaml", "dm_raw", workflow_path)
+  expect_true(file.exists(path))
+
+  # An already-valid path is used as-is rather than being re-rooted.
+  expect_equal(.ResolveSpecPath(path, "dm_raw", workflow_path), path)
+
+  expect_error(
+    .ResolveSpecPath("nope_spec.yaml", "dm_raw", workflow_path),
+    "Spec file for domain 'dm_raw' not found"
+  )
+})
+
+test_that(".LoadSpec converges file and inline specs on one representation (#91)", {
+  inline <- list(steps = list("rows_distinct"))
+  expect_identical(.LoadSpec(inline, "pointblank_inline", "d"), inline)
+
+  workflow_path <- system.file(
+    "example_workflows/04_Example_RAW_TO_SDTM/DM.yaml",
+    package = "workr"
+  )
+  skip_if(workflow_path == "")
+  loaded <- .LoadSpec(
+    "DM_dm_raw_spec.yaml",
+    "pointblank_file",
+    "dm_raw",
+    workflow_path
+  )
+  expect_true(is.list(loaded))
+  expect_true("steps" %in% names(loaded))
+})
+
+test_that(".EnforceSpecResult applies the failure contract (#91)", {
+  base <- list(
+    domain = "d",
+    n_steps = 2,
+    n_failed_steps = 1,
+    failed_steps = "col_exists"
+  )
+
+  expect_error(
+    .EnforceSpecResult(utils::modifyList(base, list(level = "error"))),
+    "Spec validation failed for 'd' at level 'error'"
+  )
+  expect_error(
+    .EnforceSpecResult(utils::modifyList(base, list(level = "critical"))),
+    "at level 'critical'"
+  )
+  expect_message(
+    .EnforceSpecResult(utils::modifyList(base, list(level = "warning"))),
+    "Spec validation warning for 'd'"
+  )
+  expect_silent(
+    .EnforceSpecResult(utils::modifyList(base, list(level = "pass")))
+  )
+})
+
+test_that(".CheckSpecDomain dispatches on dialect (#91)", {
+  skip_if_not_installed("pointblank")
+
+  legacy <- .CheckSpecDomain(make_df(), list(required_cols = "STUDYID"), "d")
+  expect_equal(legacy$dialect, "legacy")
+
+  pb <- suppressMessages(
+    .CheckSpecDomain(make_df(), list(steps = list("rows_distinct")), "d")
+  )
+  expect_equal(pb$dialect, "pointblank")
+})
+
+test_that("CheckSpec preserves domain order and names in its results (#91)", {
+  res <- CheckSpec(
+    list(b = data.frame(x = 1), a = data.frame(y = 2)),
+    list(b = list(required_cols = "x"), a = list(required_cols = "y"))
+  )
+  expect_equal(names(res), c("b", "a"))
+})
+
+test_that("`*_spec.yaml` files are not discovered as workflows (#91)", {
+  files <- ListWorkflows(strPath = "example_workflows", strPackage = "workr")
+  expect_false(any(grepl("_spec\\.ya?ml$", basename(files))))
+})
+
+# --- Translation-layer edge cases (#91) ----------------------------------
+
+test_that(".PbThresholdArgs handles empty and absent thresholds (#91)", {
+  expect_identical(.PbThresholdArgs(NULL), list())
+  expect_identical(.PbThresholdArgs(list()), list())
+})
+
+test_that(".PbThresholdArgs requires a named mapping (#91)", {
+  # `thresholds: [0.1, 0.2]` is meaningless: severity is carried by the key.
+  expect_error(
+    .PbThresholdArgs(list(0.1, 0.2)),
+    "`thresholds` must be a named mapping"
+  )
+})
+
+test_that(".PbThresholdArgs warns on unknown levels and drops them (#91)", {
+  expect_warning(
+    args <- .PbThresholdArgs(list(warning = 0.1, oops = 0.5)),
+    "Ignoring unrecognized threshold level\\(s\\): oops"
+  )
+  expect_identical(args, list(warn_at = 0.1))
+})
+
+test_that(".PbThresholdArgs accepts the YAML *_fraction spellings (#91)", {
+  expect_identical(
+    .PbThresholdArgs(list(warn_fraction = 0.1, stop_fraction = 0.2)),
+    list(warn_at = 0.1, stop_at = 0.2)
+  )
+})
+
+test_that(".PbActionLevels returns NULL for no arguments (#91)", {
+  expect_null(.PbActionLevels(list()))
+})
+
+test_that(".PbTranslateStep coerces non-list step arguments (#91)", {
+  # `col_exists: STUDYID` parses as a bare character, not a list.
+  step <- .PbTranslateStep(list(col_exists = "STUDYID"))
+  expect_identical(step$method, "col_exists")
+  expect_identical(step$args, list("STUDYID"))
+})
+
+test_that(".PbTranslateStep rejects malformed steps (#91)", {
+  msg <- "Each entry of `steps` must be a validation method name or a single-key mapping"
+  expect_error(.PbTranslateStep(list("col_exists")), msg)
+  expect_error(.PbTranslateStep(42), msg)
+  expect_error(.PbTranslateStep(c("a", "b")), msg)
+})
+
+test_that(".PbTranslateStep warns on methods outside the portable subset (#91)", {
+  # Valid in R pointblank, but not guaranteed to exist in Python pointblank.
+  expect_warning(
+    step <- .PbTranslateStep(list(col_vals_expr = "~ TRUE")),
+    "outside the cross-language portable subset"
+  )
+  expect_identical(step$method, "col_vals_expr")
+})
+
+test_that(".PbInterrogate logs that a spec-supplied `tbl` is ignored (#91)", {
+  skip_if_not_installed("pointblank")
+
+  # `tbl:` is an R formula in R and a lambda in Python -- the one field that
+  # provably cannot round-trip -- so workflow-supplied data always wins.
+  expect_message(
+    .PbInterrogate(
+      make_df(),
+      list(tbl = "~ some_other_data", steps = list("rows_distinct")),
+      "d"
+    ),
+    "Ignoring `tbl` in spec"
+  )
+})
+
+test_that(".PbInterrogate errors on an unknown validation method (#91)", {
+  skip_if_not_installed("pointblank")
+
+  expect_error(
+    suppressWarnings(
+      .PbInterrogate(make_df(), list(steps = list("col_vals_nonsense")), "d")
+    ),
+    "Unknown pointblank validation method: 'col_vals_nonsense'"
+  )
+})
+
+test_that(".PbSummarize reports the critical level on a notify breach (#91)", {
+  skip_if_not_installed("pointblank")
+
+  agent <- suppressMessages(
+    .PbInterrogate(
+      make_df(),
+      list(
+        thresholds = list(critical = 1),
+        steps = list(list(rows_distinct = list(columns = "STUDYID")))
+      ),
+      "d"
+    )
+  )
+  result <- .PbSummarize(agent, "d")
+
+  expect_identical(result$level, "critical")
+  expect_false(result$passed)
+})
+
+# --- 03_KRI converted specs (#91) ----------------------------------------
+
+kri_path <- function(file) {
+  system.file("example_workflows/03_KRI", file, package = "workr")
+}
+
+test_that("03_KRI specs pass against the example data (#91)", {
+  skip_if_not_installed("pointblank")
+  local_quiet_log("info")
+
+  source(kri_path("initData.R"), local = TRUE)
+  lData <- initData()
+
+  expect_silent(
+    CheckSpec(
+      lData,
+      list(Raw_SUBJ = "SUBJ_Raw_SUBJ_spec.yaml"),
+      strPath = kri_path("SUBJ.yaml")
+    )
+  )
+  expect_silent(
+    CheckSpec(
+      lData,
+      list(Raw_AE = "AE_Raw_AE_spec.yaml"),
+      strPath = kri_path("AE.yaml")
+    )
+  )
+})
+
+test_that("03_KRI specs actually enforce declared types (#91)", {
+  skip_if_not_installed("pointblank")
+  local_quiet_log("info")
+
+  # The legacy format declared types but never checked them. This is the
+  # behavior change the conversion buys, so assert it rather than trust it.
+  source(kri_path("initData.R"), local = TRUE)
+  lData <- initData()
+  lData$Raw_SUBJ$timeonstudy <- as.character(lData$Raw_SUBJ$timeonstudy)
+
+  expect_error(
+    CheckSpec(
+      lData,
+      list(Raw_SUBJ = "SUBJ_Raw_SUBJ_spec.yaml"),
+      strPath = kri_path("SUBJ.yaml")
+    ),
+    "col_is_integer"
+  )
+})
+
+test_that("03_KRI specs catch a dropped column (#91)", {
+  skip_if_not_installed("pointblank")
+  local_quiet_log("info")
+
+  source(kri_path("initData.R"), local = TRUE)
+  lData <- initData()
+  lData$Raw_AE$aetoxgr <- NULL
+
+  expect_error(
+    CheckSpec(
+      lData,
+      list(Raw_AE = "AE_Raw_AE_spec.yaml"),
+      strPath = kri_path("AE.yaml")
+    ),
+    "col_exists"
+  )
+})
+
+test_that("spec failure messages are not buried by iteration context (#91)", {
+  skip_if_not_installed("pointblank")
+  local_quiet_log("info")
+
+  # `purrr::map()` prefixed aborts with "In index: N", pushing the actual
+  # diagnosis out of view. The domain name already identifies the failure.
+  err <- tryCatch(
+    CheckSpec(
+      list(d = data.frame(x = "a", stringsAsFactors = FALSE)),
+      list(
+        d = list(
+          thresholds = list(error = 0.01),
+          steps = list(list(col_is_numeric = list(columns = "x")))
+        )
+      )
+    ),
+    error = function(e) conditionMessage(e)
+  )
+
+  expect_match(err, "^Spec validation failed for 'd'")
+  expect_no_match(err, "In index")
+})
+
+test_that("all 03_KRI workflows use the pointblank dialect (#91)", {
+  # Guards against a legacy block creeping back in during future edits.
+  for (file in c("SUBJ.yaml", "AE.yaml", "kri0001.yaml")) {
+    spec <- yaml::read_yaml(kri_path(file))$spec
+
+    for (domain in names(spec)) {
+      expect_identical(
+        .SpecDialect(spec[[domain]], domain),
+        "pointblank_file",
+        info = paste(file, domain)
+      )
+    }
+  }
+})
+
+# --- Workflows 05-07 converted specs (#91) -------------------------------
+
+read_advs <- function() {
+  path <- system.file(
+    "demo_gsmpharmaverse/data/ADAM/ADAM_ADVS.parquet",
+    package = "workr"
+  )
+  skip_if(path == "", "ADAM_ADVS.parquet not installed")
+  arrow::read_parquet(path)
+}
+
+wf_spec <- function(dir, file) {
+  path <- system.file(
+    file.path("example_workflows", dir, file),
+    package = "workr"
+  )
+  # Workflow files carry `!expr` tags in their `steps:`; we only read `spec:`,
+  # so the "requires eval.expr=TRUE" warning is irrelevant noise here.
+  list(spec = suppressWarnings(yaml::read_yaml(path))$spec, path = path)
+}
+
+test_that("workflow 05-07 specs pass against their example data (#91)", {
+  skip_if_not_installed("pointblank")
+  skip_if_not_installed("arrow")
+  local_quiet_log("info")
+
+  sdtm <- function(name) {
+    p <- system.file(
+      file.path("demo_gsmpharmaverse/data/SDTM", name),
+      package = "workr"
+    )
+    skip_if(p == "", paste(name, "not installed"))
+    arrow::read_parquet(p)
+  }
+
+  advs <- read_advs()
+  cases <- list(
+    list(
+      "05_Example_SDTM_TO_ADAM",
+      "ADVS.yaml",
+      list(SDTM_DM = sdtm("SDTM_DM.parquet"), SDTM_VS = sdtm("SDTM_VS.parquet"))
+    ),
+    list("06_Example_ADAM_TO_TFL", "WorkProduct1.yaml", list(ADVS = advs)),
+    list(
+      "07_Example_ADAM_TO_ARS",
+      "table_mean_arterial_pressure.yaml",
+      list(ADVS = advs)
+    )
+  )
+
+  for (case in cases) {
+    wf <- wf_spec(case[[1]], case[[2]])
+    expect_no_error(CheckSpec(case[[3]], wf$spec, strPath = wf$path))
+  }
+})
+
+test_that("workflow 07 spec catches type, missing, and null violations (#91)", {
+  skip_if_not_installed("pointblank")
+  skip_if_not_installed("arrow")
+  local_quiet_log("info")
+
+  # The legacy `_all: {required: true}` wildcard was inert -- it validated
+  # nothing at all. These assertions are what the conversion buys.
+  advs <- read_advs()
+  wf <- wf_spec("07_Example_ADAM_TO_ARS", "table_mean_arterial_pressure.yaml")
+
+  broken <- advs
+  broken$AVAL <- as.character(broken$AVAL)
+  expect_error(
+    CheckSpec(list(ADVS = broken), wf$spec, strPath = wf$path),
+    "col_is_numeric"
+  )
+
+  dropped <- advs
+  dropped$PARAMCD <- NULL
+  expect_error(
+    CheckSpec(list(ADVS = dropped), wf$spec, strPath = wf$path),
+    "col_exists"
+  )
+
+  nulled <- advs
+  nulled$PARAMCD[1:5] <- NA_character_
+  expect_error(
+    CheckSpec(list(ADVS = nulled), wf$spec, strPath = wf$path),
+    "col_vals_not_null"
+  )
+})
+
+test_that("example workflow specs are all in a recognized dialect (#91)", {
+  # Every domain spec must classify as a pointblank spec or as the `_all`
+  # wildcard. Anything else means a spec shape has drifted into a form that
+  # silently validates nothing.
+  files <- ListWorkflows(strPath = "example_workflows", strPackage = "workr")
+
+  for (file in files) {
+    spec <- suppressWarnings(yaml::read_yaml(file))$spec
+    if (is.null(spec)) {
+      next
+    }
+
+    for (domain in names(spec)) {
+      dialect <- .SpecDialect(spec[[domain]], domain)
+      expect_true(
+        dialect %in%
+          c("pointblank_file", "pointblank_inline") ||
+          .SpecWildcardRequired(spec[[domain]]),
+        info = paste(basename(file), domain)
+      )
+    }
+  }
+})

--- a/tests/testthat/test-spec-pointblank.R
+++ b/tests/testthat/test-spec-pointblank.R
@@ -551,6 +551,9 @@ test_that("spec failure messages are not buried by iteration context (#91)", {
 })
 
 test_that("all 03_KRI workflows use the pointblank dialect (#91)", {
+  skip_if_not_installed("pointblank")
+  skip_if_not_installed("arrow")
+
   # Guards against a legacy block creeping back in during future edits.
   for (file in c("SUBJ.yaml", "AE.yaml", "kri0001.yaml")) {
     spec <- yaml::read_yaml(kri_path(file))$spec

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -21,7 +21,7 @@ We introduce {workr} as a simple, auditable workflow engine for R, and demonstra
 
 ## Workflow model
 
-{workr} workflows are YAML files with two sections:
+{workr} workflows are YAML files with two required sections:
 
 1. Meta: workflow metadata and configuration
 2. Steps: an ordered list of function calls

--- a/vignettes/validating-workflow-inputs.Rmd
+++ b/vignettes/validating-workflow-inputs.Rmd
@@ -1,0 +1,223 @@
+---
+title: "Validating Workflow Inputs"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Validating Workflow Inputs}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  message = FALSE
+)
+```
+
+```{r setup, include = FALSE}
+library(workr)
+```
+
+# Overview
+
+A workflow YAML file has three sections. `meta` and `steps` describe *what to run*; the optional `spec` section describes *what must be true of the data before running it*.
+
+```yaml
+meta:
+  ID: demographics
+spec:
+  adsl: adsl_spec.yaml
+steps:
+  - output: summary
+    name: summarise_subjects
+    params:
+      df: adsl
+```
+
+`spec` is a mapping from input names to their validation rules. The names must match entries in the workflow's data list (`lData`), and validation runs once, before the first step. Catching a missing column here produces a clear message about the input, rather than an obscure error from deep inside a step.
+
+Validation is entirely optional. A workflow with no `spec` section runs exactly as before.
+
+# Two ways to write a spec
+
+Each input's spec is written in one of two forms.
+
+## The `_all` wildcard
+
+Use `_all` to say an input is needed without describing its shape:
+
+```yaml
+spec:
+  adsl:
+    _all:
+      required: true
+```
+
+This asserts only that the input is present and non-empty — at least one row and at least one column. It names no columns, so it deliberately claims nothing about them, including their types or whether they contain missing values.
+
+`_all` is a placeholder for inputs you are not picky about. It documents that a workflow depends on an input and catches the case where that input arrives empty, which is a common symptom of an upstream query returning nothing. When you want real column-level guarantees, use a spec file instead.
+
+## Spec files
+
+For anything more specific, point the input at a YAML file:
+
+```yaml
+spec:
+  adsl: adsl_spec.yaml
+```
+
+The path is resolved relative to the workflow file, so specs usually live beside the workflows that use them. Keeping them in separate files means several workflows can share one spec, and a spec can be reviewed on its own.
+
+These files use the YAML dialect of [pointblank](https://rstudio.github.io/pointblank/), which is what {workr} uses to run the validation. `pointblank` is an optional dependency: install it only if you use spec files.
+
+# Writing a spec file
+
+A spec file names the table, sets severity thresholds, and lists validation steps:
+
+```yaml
+# adsl_spec.yaml
+tbl_name: adsl
+label: Subject-level analysis dataset
+thresholds:
+  error: 0.01
+steps:
+  - col_exists:
+      columns: [USUBJID, SITEID, AGE]
+  - col_is_character:
+      columns: [USUBJID, SITEID]
+  - col_vals_not_null:
+      columns: [USUBJID]
+  - rows_distinct:
+      columns: [USUBJID]
+```
+
+Each entry under `steps` is a pointblank validation function and its arguments. Listing several columns applies the check to each one independently. A step that takes no arguments can be written as a bare string:
+
+```yaml
+steps:
+  - rows_distinct
+```
+
+Do not include a `tbl:` key. {workr} supplies the data frame from the workflow's data list, and any `tbl:` in the file is ignored.
+
+## Common validation steps
+
+| Step | Asserts |
+|---|---|
+| `col_exists` | The column is present |
+| `col_vals_not_null` | No missing values |
+| `col_vals_in_set` | Values fall within an allowed set |
+| `col_vals_between` | Numeric values fall in a range |
+| `col_vals_regex` | Values match a pattern |
+| `rows_distinct` | No duplicate rows across the given columns |
+| `rows_complete` | No missing values across the given columns |
+| `col_is_character`, `col_is_numeric`, `col_is_integer`, `col_is_date`, `col_is_posix`, `col_is_logical`, `col_is_factor` | The column has the given type |
+
+Two notes on type checks that surprise people:
+
+- `col_is_numeric` tests for *double* and will fail on an integer column. Use `col_is_integer` for counts and other whole-number columns.
+- A column can carry a class attribute that does not match its storage. Date-like strings read from Parquet, for example, may arrive as character storage with a non-character class, satisfying neither `col_is_character` nor `col_is_date`. When no type check fits, assert `col_exists` and leave the type alone.
+
+# Thresholds and failure behavior
+
+`thresholds` sets how much failure is tolerated before each severity level triggers. A value below 1 is a *fraction* of failing rows; a whole number is a *count*.
+
+```yaml
+thresholds:
+  warning: 0.01   # more than 1% of rows failing raises a warning
+  error: 0.05     # more than 5% failing is an error
+```
+
+The three levels behave differently:
+
+| Level | Effect |
+|---|---|
+| `warning` | Logged; the workflow continues |
+| `error` | Aborts the workflow |
+| `critical` | Aborts the workflow |
+
+This distinction is the main reason to set thresholds deliberately. A `warning` lets a pipeline proceed on data that is imperfect but usable, while `error` stops it before a downstream step produces something misleading.
+
+A step can override the thresholds for itself:
+
+```yaml
+steps:
+  - col_vals_not_null:
+      columns: [AGE]
+      thresholds:
+        warning: 0.10
+```
+
+If an input has no `thresholds` at all, pointblank records failures but nothing escalates, so the workflow proceeds. Set thresholds on any spec whose failures should actually stop a run.
+
+# A worked example
+
+Consider this dataset and spec:
+
+```{r}
+adsl <- data.frame(
+  USUBJID = c("S001", "S002", "S003"),
+  SITEID  = c("01", "01", "02"),
+  AGE     = c(54L, 61L, 47L),
+  stringsAsFactors = FALSE
+)
+
+spec <- list(
+  tbl_name = "adsl",
+  thresholds = list(error = 0.01),
+  steps = list(
+    list(col_exists = list(columns = c("USUBJID", "SITEID", "AGE"))),
+    list(col_vals_not_null = list(columns = "USUBJID")),
+    list(rows_distinct = list(columns = "USUBJID"))
+  )
+)
+```
+
+Validation runs as part of the workflow, so the check happens through `RunWorkflow()`:
+
+```{r}
+lWorkflow <- list(
+  meta = list(ID = "demographics"),
+  spec = list(adsl = spec),
+  steps = list(
+    list(name = "nrow", output = "n", params = list(x = "adsl"))
+  )
+)
+
+RunWorkflow(lWorkflow = lWorkflow, lData = list(adsl = adsl))
+```
+
+Introduce a missing subject identifier and the run stops before any step executes:
+
+```{r, error = TRUE}
+adsl$USUBJID[2] <- NA
+
+RunWorkflow(lWorkflow = lWorkflow, lData = list(adsl = adsl))
+```
+
+The message names the input, the severity, and which checks failed. Had the spec used `warning: 0.01` instead of `error: 0.01`, the same failure would have been logged and the workflow would have continued.
+
+# Portability
+
+Spec files use pointblank's cross-language YAML dialect, so the same file can be read by both the R and Python implementations of pointblank. This matters when a validation contract is shared between teams working in different languages: the spec is data, not code, and neither side owns it.
+
+Two things to keep in mind if you want a spec to remain portable:
+
+- Omit `tbl:`. It is a formula in R and a lambda in Python, and it is the one field that cannot round-trip. {workr} ignores it regardless.
+- Prefer widely available validation steps. {workr} warns when a spec uses a step outside the portable subset, since it may not behave identically in Python.
+
+The `_all` wildcard is specific to {workr} and has no pointblank equivalent, so an input using `_all` is not portable. That is usually fine: `_all` is for inputs you are not making promises about anyway.
+
+# Where to look next
+
+The bundled examples show both styles in place:
+
+```{r}
+list.files(
+  system.file("example_workflows", "03_KRI", package = "workr"),
+  pattern = "\\.yaml$"
+)
+```
+
+Workflows `03_KRI` through `07_Example_ADAM_TO_ARS` pair each workflow with its spec files, and `04_Example_RAW_TO_SDTM/VS.yaml` shows `_all` used for inputs whose shape does not need pinning down.

--- a/vignettes/validating-workflow-inputs.Rmd
+++ b/vignettes/validating-workflow-inputs.Rmd
@@ -77,7 +77,7 @@ A spec file names the table, sets severity thresholds, and lists validation step
 
 ```yaml
 # adsl_spec.yaml
-tbl_name: adsl
+tbl: adsl
 label: Subject-level analysis dataset
 thresholds:
   error: 0.01
@@ -99,7 +99,7 @@ steps:
   - rows_distinct
 ```
 
-Do not include a `tbl:` key. {workr} supplies the data frame from the workflow's data list, and any `tbl:` in the file is ignored.
+`tbl:` names the table to validate. {workr} resolves that name in the workflow's data list, so it matches how pointblank resolves `tbl:` against objects in its execution environment. If `tbl:` is omitted, the input's name under `spec:` is used.
 
 ## Common validation steps
 
@@ -164,7 +164,7 @@ adsl <- data.frame(
 )
 
 spec <- list(
-  tbl_name = "adsl",
+  tbl = "adsl",
   thresholds = list(error = 0.01),
   steps = list(
     list(col_exists = list(columns = c("USUBJID", "SITEID", "AGE"))),
@@ -204,7 +204,7 @@ Spec files use pointblank's cross-language YAML dialect, so the same file can be
 
 Two things to keep in mind if you want a spec to remain portable:
 
-- Omit `tbl:`. It is a formula in R and a lambda in Python, and it is the one field that cannot round-trip. {workr} ignores it regardless.
+- Write `tbl:` as a plain name (`tbl: adsl`). R pointblank's own examples use formula form (`tbl: ~ adsl`), which {workr} also accepts, but the bare name reads identically in both languages.
 - Prefer widely available validation steps. {workr} warns when a spec uses a step outside the portable subset, since it may not behave identically in Python.
 
 The `_all` wildcard is specific to {workr} and has no pointblank equivalent, so an input using `_all` is not portable. That is usually fine: `_all` is for inputs you are not making promises about anyway.


### PR DESCRIPTION
Closes #91.

Adopts [pointblank](https://rstudio.github.io/pointblank/) as the validation engine behind `CheckSpec()`, via a translation layer that lets one `*_spec.yaml` file be read by both R and Python pointblank.

## Why a translation layer

R pointblank's YAML reader silently discards every top-level key it does not recognize — including `thresholds:`. A spec written in Python form would interrogate in R with **no severity levels at all and report success**, which is the worst possible failure mode for a validation pipeline.

So rather than going through pointblank's YAML reader, this parses the spec and drives the public API (`create_agent()` + `do.call()` per step). That gives us control over the failure mode: unrecognized keys now warn instead of vanishing. The layer also handles the mechanical R/Python gaps — `col_vals_le`/`col_vals_ge`, `pattern:`/`regex:`, bare-string steps like `- rows_distinct`, and the severity name mapping.

## What a spec looks like

`spec` entries are either a path to a spec file, or the `_all` wildcard:

```yaml
spec:
  Raw_SUBJ: SUBJ_Raw_SUBJ_spec.yaml   # column-level expectations
  Raw_AE:
    _all:
      required: true                   # present and non-empty; nothing more
```

Paths resolve relative to the workflow file. `_all` keeps its existing loose meaning by design — it is the placeholder for inputs nobody wants to be picky about.

Failure contract: `error` and `critical` abort before any step runs; `warning` is logged and execution continues.

`pointblank` is in `Suggests` and only required when a workflow actually uses a spec file.

## Behavior change worth flagging

The previous spec format parsed `type:` declarations but never enforced them. Converting a spec to the new format makes those checks real, so a workflow that passes today can start failing on unchanged data. That is the intent, but it is the thing to watch when converting a spec you did not write.

Two type-check traps this surfaced, both now documented:

- `col_is_numeric` tests for *double* and fails on integer columns — use `col_is_integer`.
- A column's class can disagree with its storage. `VSDTC` read from Parquet is character storage with an `iso8601` class, satisfying neither `col_is_character` nor `col_is_date`. Where no type check fits, it asserts `col_exists` only.

## Also in here

- New "Validating Workflow Inputs" vignette; `Overview.Rmd` corrected, since it described workflows as having only two sections.
- Example workflows 03–07 converted where their inputs have expectations worth stating.
- A logging seam (`appender()`) so tests can silence expected log levels without blanket `suppressMessages()`. This removed ~400 lines of test chatter.
- `R/internal.R` and `R/spec-pointblank.R` at 100% coverage.
- Two unrelated fixes made while working here: leftover `gsm.core::RunQuery` calls in the 03_KRI examples switched to `workr::RunQuery`, and a missing trailing newline in `.gitignore`. Both were emitting warnings during test runs; the suite is now warning-free.
- The NAMESPACE reformatting is roxygen 8.1.0 output, not a hand edit.

## Verification

All 651 tests pass.

## Notes for review

- **Python compatibility is by construction, not tested here.** The spec files are byte-identical inputs, but nothing in this PR runs Python pointblank against them. That is the main open risk.
- **Step-level thresholds merge over global ones.** On 0.12.4, passing step-level `actions` replaces the global `action_levels` outright, so a step tightening only `warning` would silently drop the global `error`. Merging seemed the safer reading, but I have not confirmed Python's precedence — flagged with a TODO in the source.
- **`columns: [a, b]` expanding to multiple steps is undocumented** in R pointblank. It works and is tested, but it is not a guaranteed behavior.
- **04's `VS.yaml` still uses `_all`.** Its inputs come from `sdtm.oak`'s raw CSVs, which were not available in my environment, and writing a spec I could not verify against real data would recreate the exact problem this PR fixes.